### PR TITLE
Added a version check for compatibility with OpenCV 3.0.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,9 @@ project(examples)
 cmake_minimum_required(VERSION 2.8.10)
 
 # The examples need a few additional dependencies (e.g. boost filesystem and OpenCV highgui):
+
+#check installed version in order to include the correct OpenCV libraries
+#version variable is defined from project root's CMakeLists
 if("${OpenCV_VERSION_MAJOR}$" EQUAL 2)
   message(STATUS "OpenCV 2.x detected")
   find_package(OpenCV 2.4.3 REQUIRED core imgproc highgui)


### PR DESCRIPTION
OpenCV's `imread` function has moved from `highgui` to the `imgcodecs` module in version 3.0. We can ensure compatibility by automatically choosing the right libraries in CMake.
