### PR TITLE
Added Matlab bindings for the fitting function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "3rdparty/eigen3-nnls"]
 	path = 3rdparty/eigen3-nnls
 	url = https://github.com/hmatuschek/eigen3-nnls.git
+[submodule "3rdparty/mexplus"]
+	path = 3rdparty/mexplus
+	url = https://github.com/kyamagu/mexplus.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,3 +180,7 @@ endif()
 if(BUILD_DOCUMENTATION)
 	add_subdirectory(doc)
 endif()
+
+if(GENERATE_MATLAB_BINDINGS)
+	add_subdirectory(matlab)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ option(BUILD_DOCUMENTATION "Build the library documentation." OFF)
 message(STATUS "BUILD_DOCUMENTATION: ${BUILD_DOCUMENTATION}")
 option(GENERATE_PYTHON_BINDINGS "Build python bindings. Needs BUILD_UTILS enabled too." OFF)
 message(STATUS "GENERATE_PYTHON_BINDINGS: ${GENERATE_PYTHON_BINDINGS}")
+option(GENERATE_MATLAB_BINDINGS "Build Matlab bindings. Requires Matlab with the compiler installed or the Matlab Compiler Runtime." OFF)
+message(STATUS "GENERATE_MATLAB_BINDINGS: ${GENERATE_MATLAB_BINDINGS}")
+
 
 # Build a CPack driven installer package:
 include(InstallRequiredSystemLibraries) # This module will include any runtime libraries that are needed by the project for the current platform

--- a/initial_cache.cmake.template
+++ b/initial_cache.cmake.template
@@ -24,6 +24,10 @@
 # ==============================
 #set(PYTHON_EXECUTABLE "C:\\Users\\user\\AppData\\Local\\Programs\\Python\\Python35\\python.exe" CACHE PATH "Path to the python interpreter." FORCE)
 
+# Set the path to the Matlab root directory if you want to build the Matlab bindings and it doesn't find Matlab automatically:
+# ==============================
+#set(Matlab_ROOT_DIR "/opt/matlab" CACHE PATH "Path to the Matlab installation directory." FORCE)
+
 # Configuration options
 # ==============================
 set(BUILD_EXAMPLES ON CACHE BOOL "Build the example applications." FORCE)

--- a/initial_cache.cmake.template
+++ b/initial_cache.cmake.template
@@ -31,3 +31,4 @@ set(BUILD_CERES_EXAMPLE OFF CACHE BOOL "Build the fit-model-ceres example (requi
 set(BUILD_UTILS OFF CACHE BOOL "Build utility applications." FORCE)
 set(BUILD_DOCUMENTATION OFF CACHE BOOL "Build the library documentation." FORCE)
 set(GENERATE_PYTHON_BINDINGS OFF CACHE BOOL "Build python bindings. Needs BUILD_UTILS enabled too." FORCE)
+set(GENERATE_MATLAB_BINDINGS OFF CACHE BOOL "Build Matlab bindings. Requires Matlab with the compiler installed or the Matlab Compiler Runtime." FORCE)

--- a/matlab/+eos/+fitting/fit_shape_and_pose.m
+++ b/matlab/+eos/+fitting/fit_shape_and_pose.m
@@ -12,7 +12,7 @@ function [mesh, rendering_parameters] = fit_shape_and_pose(morphable_model, ...
 %   It fits the pose (camera), PCA shape model, and expression blendshapes
 %   in an iterative way.
 %
-%   landmarks must be a 68 x 2 vector with ibug landmarks, in the order
+%   landmarks must be a 68 x 2 matrix with ibug landmarks, in the order
 %   from 1 to 68.
 %
 %   Default values for some of the parameters:: num_iterations = 5,

--- a/matlab/+eos/+fitting/fit_shape_and_pose.m
+++ b/matlab/+eos/+fitting/fit_shape_and_pose.m
@@ -26,15 +26,11 @@ function [mesh, rendering_parameters] = fit_shape_and_pose(morphable_model, ...
 %   contour_landmarks and model_contour as *filenames* to the respective
 %   files in the eos/share/ directory, and not the objects directly.
 
-morphable_model = '../share/sfm_shape_3448.bin';
-blendshapes = '../share/expression_blendshapes_3448.bin';
-landmarks = zeros(68, 2);
-landmark_mapper = '../share/ibug2did.txt';
-image_width = 1280;
-image_height = 720;
-edge_topology = '../share/sfm_3448_edge_topology.json';
-contour_landmarks = '../share/ibug2did.txt';
-model_contour = '../share/model_contours.json';
+% We'll use default values to the following arguments, if they're not
+% provided:
+if (~exist('edge_topology', 'var')), edge_topology = '../share/sfm_3448_edge_topology.json'; end
+if (~exist('contour_landmarks', 'var')), contour_landmarks = '../share/ibug2did.txt'; end
+if (~exist('model_contour', 'var')), model_contour = '../share/model_contours.json'; end
 if (~exist('num_iterations', 'var')), num_iterations = 5; end
 if (~exist('num_shape_coefficients_to_fit', 'var')), num_shape_coefficients_to_fit = -1; end
 if (~exist('lambda', 'var')), lambda = 30.0; end

--- a/matlab/+eos/+fitting/fit_shape_and_pose.m
+++ b/matlab/+eos/+fitting/fit_shape_and_pose.m
@@ -12,26 +12,29 @@ function [mesh, rendering_parameters] = fit_shape_and_pose(morphable_model, ...
 %   It fits the pose (camera), PCA shape model, and expression blendshapes
 %   in an iterative way.
 %
-%   Default values: num_iterations = 5, num_shape_coefficients_to_fit = all
-%   (-1), and lambda = 30.0.
+%   landmarks must be a 68 x 2 vector with ibug landmarks, in the order
+%   from 1 to 68.
+%
+%   Default values for some of the parameters:: num_iterations = 5,
+%   num_shape_coefficients_to_fit = all (-1), and lambda = 30.0.
 %
 %   Please see the C++ documentation for the description of the parameters:
-%   http://patrikhuber.github.io/eos/doc/ (TODO: Update documentation!)
+%   http://patrikhuber.github.io/eos/doc/ (TODO: Update to v0.9.1!)
 %
 %   NOTE: In contrast to the C++ function, this Matlab function expects the
 %   morphable_model, blendshapes, landmark_mapper, edge_topology,
 %   contour_landmarks and model_contour as *filenames* to the respective
 %   files in the eos/share/ directory, and not the objects directly.
 
-morphable_model = '';
-blendshapes = '';
-landmarks = zeros(68, 2); % 68 x 2 vector with ibug LMs, in order! 1 to 68
-landmark_mapper = '';
+morphable_model = '../share/sfm_shape_3448.bin';
+blendshapes = '../share/expression_blendshapes_3448.bin';
+landmarks = zeros(68, 2);
+landmark_mapper = '../share/ibug2did.txt';
 image_width = 1280;
 image_height = 720;
-edge_topology = '';
-contour_landmarks = '';
-model_contour = '';
+edge_topology = '../share/sfm_3448_edge_topology.json';
+contour_landmarks = '../share/ibug2did.txt';
+model_contour = '../share/model_contours.json';
 if (~exist('num_iterations', 'var')), num_iterations = 5; end
 if (~exist('num_shape_coefficients_to_fit', 'var')), num_shape_coefficients_to_fit = -1; end
 if (~exist('lambda', 'var')), lambda = 30.0; end

--- a/matlab/+eos/+fitting/fit_shape_and_pose.m
+++ b/matlab/+eos/+fitting/fit_shape_and_pose.m
@@ -1,0 +1,26 @@
+function [mesh, rendering_parameters] = fit_shape_and_pose(morphable_model, ...
+    blendshapes, landmarks, landmark_mapper, image_width, image_height, ...
+    edge_topology, contour_landmarks, model_contour, num_iterations, ...
+    num_shape_coefficients_to_fit, lambda)
+% FIT_SHAPE_AND_POSE  Fit a 3DMM shape model to landmarks.
+%   [ mesh, rendering_parameters ] = FIT_SHAPE_AND_POSE(morphable_model, ...
+%     blendshapes, landmarks, landmark_mapper, image_width, image_height, ...
+%     edge_topology, contour_landmarks, model_contour, num_iterations, ...
+%     num_shape_coefficients_to_fit, lambda)
+%
+%   This function fits a 3D Morphable Model to landmarks in an image.
+%   It fits the pose (camera), PCA shape model, and expression blendshapes
+%   in an iterative way.
+%
+%   Please see the C++ documentation for the description of the parameters:
+%   http://patrikhuber.github.io/eos/doc/ (TODO: Update documentation!)
+%
+%   NOTE: In contrast to the C++ function, this Matlab function expects the
+%   morphable_model, blendshapes, landmark_mapper, edge_topology,
+%   contour_landmarks and model_contour as *filenames* to the respective
+%   files in the eos/share/ directory, and not the objects directly.
+
+mesh = fitting(1, [1, 2, 3; 4, 5, 6]);
+rendering_parameters = [];
+
+end

--- a/matlab/+eos/+fitting/fit_shape_and_pose.m
+++ b/matlab/+eos/+fitting/fit_shape_and_pose.m
@@ -12,6 +12,9 @@ function [mesh, rendering_parameters] = fit_shape_and_pose(morphable_model, ...
 %   It fits the pose (camera), PCA shape model, and expression blendshapes
 %   in an iterative way.
 %
+%   Default values: num_iterations = 5, num_shape_coefficients_to_fit = all
+%   (-1), and lambda = 30.0.
+%
 %   Please see the C++ documentation for the description of the parameters:
 %   http://patrikhuber.github.io/eos/doc/ (TODO: Update documentation!)
 %
@@ -20,7 +23,19 @@ function [mesh, rendering_parameters] = fit_shape_and_pose(morphable_model, ...
 %   contour_landmarks and model_contour as *filenames* to the respective
 %   files in the eos/share/ directory, and not the objects directly.
 
-mesh = fitting(1, [1, 2, 3; 4, 5, 6]);
-rendering_parameters = [];
+morphable_model = '';
+blendshapes = '';
+landmarks = zeros(68, 2); % 68 x 2 vector with ibug LMs, in order! 1 to 68
+landmark_mapper = '';
+image_width = 1280;
+image_height = 720;
+edge_topology = '';
+contour_landmarks = '';
+model_contour = '';
+if (~exist('num_iterations', 'var')), num_iterations = 5; end
+if (~exist('num_shape_coefficients_to_fit', 'var')), num_shape_coefficients_to_fit = -1; end
+if (~exist('lambda', 'var')), lambda = 30.0; end
+
+[ mesh, rendering_parameters ] = fitting(morphable_model, blendshapes, landmarks, landmark_mapper, image_width, image_height, edge_topology, contour_landmarks, model_contour, num_iterations, num_shape_coefficients_to_fit, lambda);
 
 end

--- a/matlab/+eos/+fitting/private/fitting.cpp
+++ b/matlab/+eos/+fitting/private/fitting.cpp
@@ -103,7 +103,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	// Return the mesh and the rendering_parameters:
 	OutputArguments output(nlhs, plhs, 2);
 	output.set(0, mesh);
-	output.set(1, landmarks_in); // RenderingParameters
+	output.set(1, rendering_parameters);
 };
 
 void func()

--- a/matlab/+eos/+fitting/private/fitting.cpp
+++ b/matlab/+eos/+fitting/private/fitting.cpp
@@ -26,24 +26,30 @@
 #include "mex.h"
 //#include "matrix.h"
 
+#include <string>
+
 using namespace mexplus;
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-	using std::vector;
+	using std::string;
 	// Check for proper number of input and output arguments:
 	mexPrintf("nlhs: %d, nrhs: %d\n", nlhs, nrhs);
-	if (nrhs != 2) {
-		mexErrMsgIdAndTxt("eos:example:nargin", "Example requires two input arguments.");
+	if (nrhs != 12) {
+		mexErrMsgIdAndTxt("eos:example:nargin", "fit_shape_and_pose requires 12 input arguments.");
 	}
-	else if (nlhs >= 2) { // 'nlhs >= 1' means no output argument apparently?
-		mexErrMsgIdAndTxt("eos:example:nargout", "Example requires zero or one output arguments.");
+	if (nlhs != 2) { // 'nlhs >= 1' means no output argument apparently?
+		mexErrMsgIdAndTxt("eos:example:nargout", "fit_shape_and_pose returns two output arguments.");
 	}
 
-	InputArguments input(nrhs, prhs, 2);
-	double vin1 = input.get<double>(0);
+	InputArguments input(nrhs, prhs, 12);
+	auto morphablemodel_file = input.get<string>(0);
+	auto blendshapes_file = input.get<string>(1);
+	auto landmarks = input.get<Eigen::MatrixXd>(2);
+//	auto mm = input.get<string>(0);
+//	double vin1 = input.get<double>(0);
 	// Matlab stores col-wise in memory - hence the entry of the second row comes first
-	auto vin2 = input.get<vector<double>>(1);
+	//auto vin2 = input.get<vector<double>>(1);
 /*	auto test = input[1];
 	MxArray mxa(test);
 	auto ndim = mxa.dimensionSize();
@@ -57,18 +63,19 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 */
 	//auto x = MxArray::Numeric<double>(2, 2);
 
-	auto asdf = input.get<Eigen::MatrixXd>(1);
+/*	auto asdf = input.get<Eigen::MatrixXd>(1);
 	std::stringstream ss2;
 	ss2 << asdf;
-	std::string msg2 = ss2.str();
+	std::string msg2 = ss2.str();*/
 
-	OutputArguments output(nlhs, plhs, 1);
-	output.set(0, asdf);
+	OutputArguments output(nlhs, plhs, 2);
+	output.set(0, landmarks);
+	output.set(1, landmarks);
 
 	//double *vin1, *vin2;
 	//vin1 = (double*)mxGetPr(prhs[0]);
 	//vin2 = (double*)mxGetPr(prhs[1]);
-	mexPrintf("%f, %f\n", vin1, vin2[0]);
+	//mexPrintf("%f, %f\n", vin1, vin2[0]);
 };
 
 void func()

--- a/matlab/+eos/+fitting/private/fitting.cpp
+++ b/matlab/+eos/+fitting/private/fitting.cpp
@@ -27,6 +27,7 @@
 #include "eos/render/Mesh.hpp"
 
 #include "mexplus_eigen.hpp"
+#include "mexplus_eos_types.hpp"
 
 #include "mexplus.h"
 
@@ -46,7 +47,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
 	using std::string;
 	// Check for proper number of input and output arguments:
-	mexPrintf("nlhs: %d, nrhs: %d\n", nlhs, nrhs);
 	if (nrhs != 12) {
 		mexErrMsgIdAndTxt("eos:fitting:nargin", "fit_shape_and_pose requires 12 input arguments.");
 	}
@@ -92,9 +92,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	fitting::RenderingParameters rendering_parameters;
 	std::tie(mesh, rendering_parameters) = fitting::fit_shape_and_pose(morphable_model, blendshapes, landmarks, landmark_mapper, image_width, image_height, edge_topology, contour_landmarks, model_contour, num_iterations, num_shape_coefficients_to_fit, lambda);
 
+	// C++ counts the vertex indices starting at zero, Matlab starts counting
+	// at one - therefore, add +1 to all triangle indices:
+	for (auto&& t : mesh.tvi) {
+		for (auto&& idx : t) {
+			idx += 1;
+		}
+	}
+
 	// Return the mesh and the rendering_parameters:
 	OutputArguments output(nlhs, plhs, 2);
-	output.set(0, landmarks_in); // the Mesh
+	output.set(0, mesh);
 	output.set(1, landmarks_in); // RenderingParameters
 };
 

--- a/matlab/+eos/+fitting/private/fitting.cpp
+++ b/matlab/+eos/+fitting/private/fitting.cpp
@@ -1,0 +1,91 @@
+/*
+ * eos - A 3D Morphable Model fitting library written in modern C++11/14.
+ *
+ * File: matlab/+eos/+fitting/private/fitting.cpp
+ *
+ * Copyright 2016 Patrik Huber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mexplus_eigen.hpp"
+
+#include "mexplus.h"
+
+#include "Eigen/Core"
+
+#include "mex.h"
+//#include "matrix.h"
+
+using namespace mexplus;
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+	using std::vector;
+	// Check for proper number of input and output arguments:
+	mexPrintf("nlhs: %d, nrhs: %d\n", nlhs, nrhs);
+	if (nrhs != 2) {
+		mexErrMsgIdAndTxt("eos:example:nargin", "Example requires two input arguments.");
+	}
+	else if (nlhs >= 2) { // 'nlhs >= 1' means no output argument apparently?
+		mexErrMsgIdAndTxt("eos:example:nargout", "Example requires zero or one output arguments.");
+	}
+
+	InputArguments input(nrhs, prhs, 2);
+	double vin1 = input.get<double>(0);
+	// Matlab stores col-wise in memory - hence the entry of the second row comes first
+	auto vin2 = input.get<vector<double>>(1);
+/*	auto test = input[1];
+	MxArray mxa(test);
+	auto ndim = mxa.dimensionSize();
+	auto nrows = mxa.dimensions()[0];
+	auto ncols = mxa.dimensions()[1];
+	Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>> em(vin2.data(), 2, 3);
+	// ==> Yes, now I can put exactly this in the MxArray namespace!
+	std::stringstream ss;
+	ss << em;
+	std::string msg = ss.str();
+*/
+	//auto x = MxArray::Numeric<double>(2, 2);
+
+	auto asdf = input.get<Eigen::MatrixXd>(1);
+	std::stringstream ss2;
+	ss2 << asdf;
+	std::string msg2 = ss2.str();
+
+	OutputArguments output(nlhs, plhs, 1);
+	output.set(0, asdf);
+
+	//double *vin1, *vin2;
+	//vin1 = (double*)mxGetPr(prhs[0]);
+	//vin2 = (double*)mxGetPr(prhs[1]);
+	mexPrintf("%f, %f\n", vin1, vin2[0]);
+};
+
+void func()
+{
+	int x = 4;
+};
+
+int func1()
+{
+	return 5;
+};
+
+class MyClass
+{
+public:
+	MyClass() = default;
+	int test() {
+		return 6;
+	};
+};

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -9,13 +9,17 @@ matlab_add_mex(
     NAME eos_fitting
     #[EXECUTABLE | MODULE | SHARED] # SHARED is the default.
     SRC +eos/+fitting/private/fitting.cpp
-    #[OUTPUT_NAME output_name]
-    +eos/+fitting/fit_shape_and_pose.m #[DOCUMENTATION file.txt]
+    OUTPUT_NAME fitting #[OUTPUT_NAME output_name]
+    # DOCUMENTATION +eos/+fitting/fit_shape_and_pose.m # doesn't work - wrong path probably. But it renames the file to fitting.m, so not what we want anyway.
     #[LINK_TO target1 target2 ...] # OpenCV etc?
     #[...]
 )
 
 target_include_directories(eos_fitting PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/mexplus/include ${CMAKE_SOURCE_DIR}/matlab/include)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/matlab/include DESTINATION matlab)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/matlab/+eos DESTINATION matlab PATTERN "*.cpp" EXCLUDE)
+install(TARGETS eos_fitting DESTINATION matlab/+eos/+fitting/private)
 
 # Todo: Look at opencv mex... eg Rect, the .c file. Do they do all the dispatching in mexFunc()?
 # Also this may have wrapping for std::vector<T>: https://github.com/kyamagu/mexopencv/blob/master/include/MxArray.hpp

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -27,6 +27,7 @@ matlab_add_mex(
 
 target_include_directories(eos_fitting PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/mexplus/include ${CMAKE_SOURCE_DIR}/matlab/include)
 
+install(FILES ${CMAKE_SOURCE_DIR}/matlab/demo.m DESTINATION matlab)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/matlab/include DESTINATION matlab)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/matlab/+eos DESTINATION matlab PATTERN "*.cpp" EXCLUDE)
 install(TARGETS eos_fitting DESTINATION matlab/+eos/+fitting/private)

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -31,6 +31,3 @@ install(FILES ${CMAKE_SOURCE_DIR}/matlab/demo.m DESTINATION matlab)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/matlab/include DESTINATION matlab)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/matlab/+eos DESTINATION matlab PATTERN "*.cpp" EXCLUDE)
 install(TARGETS eos_fitting DESTINATION matlab/+eos/+fitting/private)
-
-# Todo: Look at opencv mex... eg Rect, the .c file. Do they do all the dispatching in mexFunc()?
-# Also this may have wrapping for std::vector<T>: https://github.com/kyamagu/mexopencv/blob/master/include/MxArray.hpp

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -4,6 +4,16 @@ cmake_minimum_required(VERSION 3.7.0)
 # If Matlab_ROOT_DIR is set, the Matlab at that location is used.
 find_package(Matlab COMPONENTS MX_LIBRARY REQUIRED)
 
+# Dependencies of the modules:
+find_package(OpenCV 2.4.3 REQUIRED core)
+set_target_properties(${OpenCV_LIBS} PROPERTIES MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)
+if(MSVC)
+	# The standard find_package for boost on Win finds the dynamic libs, so for dynamic linking to boost we need to #define:
+	add_definitions(-DBOOST_ALL_NO_LIB) # Don't use the automatic library linking by boost with VS (#pragma ...). Instead, we specify everything here in cmake.
+	add_definitions(-DBOOST_ALL_DYN_LINK) # Link against the dynamic boost lib - needs to match with the version that find_package finds.
+endif()
+find_package(Boost 1.50.0 COMPONENTS system filesystem REQUIRED) # Why do we need boost for MorphableModel.hpp?
+
 # See: https://cmake.org/cmake/help/v3.7/module/FindMatlab.html?highlight=findmatlab#command:matlab_add_mex
 matlab_add_mex(
     NAME eos_fitting
@@ -11,7 +21,7 @@ matlab_add_mex(
     SRC +eos/+fitting/private/fitting.cpp
     OUTPUT_NAME fitting #[OUTPUT_NAME output_name]
     # DOCUMENTATION +eos/+fitting/fit_shape_and_pose.m # doesn't work - wrong path probably. But it renames the file to fitting.m, so not what we want anyway.
-    #[LINK_TO target1 target2 ...] # OpenCV etc?
+    LINK_TO ${OpenCV_LIBS} ${Boost_LIBRARIES} #[LINK_TO target1 target2 ...]
     #[...]
 )
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(matlab-bindings)
+cmake_minimum_required(VERSION 3.7.0)
+
+# If Matlab_ROOT_DIR is set, the Matlab at that location is used.
+find_package(Matlab COMPONENTS MX_LIBRARY REQUIRED)
+
+# See: https://cmake.org/cmake/help/v3.7/module/FindMatlab.html?highlight=findmatlab#command:matlab_add_mex
+matlab_add_mex(
+    NAME eos_matlab
+    #[EXECUTABLE | MODULE | SHARED] # SHARED is the default.
+    SRC private/test.cpp
+    #[OUTPUT_NAME output_name]
+    #[DOCUMENTATION file.txt]
+    #[LINK_TO target1 target2 ...] # OpenCV etc?
+    #[...]
+)
+
+target_include_directories(eos_matlab PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/mexplus/include)
+
+# Todo: Look at opencv mex... eg Rect, the .c file. Do they do all the dispatching in mexFunc()?
+# Also this may have wrapping for std::vector<T>: https://github.com/kyamagu/mexopencv/blob/master/include/MxArray.hpp

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -6,16 +6,16 @@ find_package(Matlab COMPONENTS MX_LIBRARY REQUIRED)
 
 # See: https://cmake.org/cmake/help/v3.7/module/FindMatlab.html?highlight=findmatlab#command:matlab_add_mex
 matlab_add_mex(
-    NAME eos_matlab
+    NAME eos_fitting
     #[EXECUTABLE | MODULE | SHARED] # SHARED is the default.
-    SRC private/test.cpp
+    SRC +eos/+fitting/private/fitting.cpp
     #[OUTPUT_NAME output_name]
-    #[DOCUMENTATION file.txt]
+    +eos/+fitting/fit_shape_and_pose.m #[DOCUMENTATION file.txt]
     #[LINK_TO target1 target2 ...] # OpenCV etc?
     #[...]
 )
 
-target_include_directories(eos_matlab PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/mexplus/include)
+target_include_directories(eos_fitting PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/mexplus/include ${CMAKE_SOURCE_DIR}/matlab/include)
 
 # Todo: Look at opencv mex... eg Rect, the .c file. Do they do all the dispatching in mexFunc()?
 # Also this may have wrapping for std::vector<T>: https://github.com/kyamagu/mexopencv/blob/master/include/MxArray.hpp

--- a/matlab/demo.m
+++ b/matlab/demo.m
@@ -1,0 +1,59 @@
+%% Demo for running the eos fitting from Matlab
+%
+%% Set up some required paths to files:
+model_file = '../share/sfm_shape_3448.bin';
+blendshapes_file = '../share/expression_blendshapes_3448.bin';
+
+%% Read some ibug landmarks for an image:
+landmarks = read_pts_landmarks('D:\Github\data\ibug\helen\testset\30427236_1.pts');
+
+%% Run the fitting, get back the fitted mesh and pose:
+[mesh, render_params] = eos.fitting.fit_shape_and_pose(model_file, blendshapes_file, landmarks);
+
+%% Visualise the fitted mesh using your favourite tool, for example...
+figure(1);
+plot3(mesh.vertices(:,1), mesh.vertices(:,2), mesh.vertices(:,3), '.');
+% or...
+FV.vertices = mesh.vertices(:,1:3);
+FV.faces = mesh.tvi;
+figure(2);
+patch(FV, 'FaceColor', [1 1 1], 'EdgeColor', 'none', 'FaceLighting', 'phong'); light; axis equal; axis off;
+
+%% Visualise the fitting in 2D, on top of the input image:
+% First we project all vertices to 2D:
+points_2d = zeros(size(mesh.vertices, 1), 2);
+h = 720; w = 1280;
+viewport = [0, h, w, -h];
+for i=1:size(mesh.vertices, 1)
+    tmp = render_params.projection*render_params.modelview*mesh.vertices(i, :)';
+    	tmp = tmp .* 0.5 + 0.5;
+		tmp(1) = tmp(1) * viewport(3) + viewport(1);
+		tmp(2) = tmp(2) * viewport(4) + viewport(2);
+        points_2d(i, :) = tmp(1:2);
+end
+% Load the image, plot the projected mesh points on top of it:
+img = imread('D:\Github\data\ibug\helen\testset\30427236_1.jpg');
+figure(3);
+imshow(img);
+hold on;
+plot(points_2d(:,1), points_2d(:,2), 'g.');
+% We can also plot the landmarks the mesh was fitted to:
+plot(landmarks(:,1), landmarks(:,2), 'ro');
+
+
+%% Just a helper function to read ibug .pts landmarks from a file:
+function [ landmarks ] = read_pts_landmarks(filename)
+
+file = fopen(filename, 'r');
+file_content = textscan(file, '%s');
+
+landmarks = zeros(68, 2);
+
+row_idx = 1;
+for i=6:2:141
+    landmarks(row_idx, 1) = str2double(file_content{1}{i});
+    landmarks(row_idx, 2) = str2double(file_content{1}{i + 1}); 
+    row_idx = row_idx + 1;
+end
+
+end

--- a/matlab/demo.m
+++ b/matlab/demo.m
@@ -3,42 +3,38 @@
 %% Set up some required paths to files:
 model_file = '../share/sfm_shape_3448.bin';
 blendshapes_file = '../share/expression_blendshapes_3448.bin';
+landmark_mappings = '../share/ibug2did.txt';
 
-%% Read some ibug landmarks for an image:
-landmarks = read_pts_landmarks('D:\Github\data\ibug\helen\testset\30427236_1.pts');
+%% Load an image and its landmarks in ibug format:
+image = imread('../bin/data/image_0010.png');
+landmarks = read_pts_landmarks('../bin/data/image_0010.pts');
+image_width = size(image, 2); image_height = size(image, 1);
 
 %% Run the fitting, get back the fitted mesh and pose:
-[mesh, render_params] = eos.fitting.fit_shape_and_pose(model_file, blendshapes_file, landmarks);
+[mesh, render_params] = eos.fitting.fit_shape_and_pose(model_file, blendshapes_file, landmarks, landmark_mappings, image_width, image_height);
+% Note: The function actually has a few more arguments to files it
+% needs. If you're not running it from within eos/matlab/, you need to
+% provide them. See its documentation and .m file.
 
-%% Visualise the fitted mesh using your favourite tool, for example...
+%% Visualise the fitted mesh using your favourite plot, for example...
 figure(1);
-plot3(mesh.vertices(:,1), mesh.vertices(:,2), mesh.vertices(:,3), '.');
+plot3(mesh.vertices(:, 1), mesh.vertices(:, 2), mesh.vertices(:, 3), '.');
 % or...
-FV.vertices = mesh.vertices(:,1:3);
+FV.vertices = mesh.vertices(:, 1:3);
 FV.faces = mesh.tvi;
 figure(2);
 patch(FV, 'FaceColor', [1 1 1], 'EdgeColor', 'none', 'FaceLighting', 'phong'); light; axis equal; axis off;
 
 %% Visualise the fitting in 2D, on top of the input image:
-% First we project all vertices to 2D:
-points_2d = zeros(size(mesh.vertices, 1), 2);
-h = 720; w = 1280;
-viewport = [0, h, w, -h];
-for i=1:size(mesh.vertices, 1)
-    tmp = render_params.projection*render_params.modelview*mesh.vertices(i, :)';
-    	tmp = tmp .* 0.5 + 0.5;
-		tmp(1) = tmp(1) * viewport(3) + viewport(1);
-		tmp(2) = tmp(2) * viewport(4) + viewport(2);
-        points_2d(i, :) = tmp(1:2);
-end
-% Load the image, plot the projected mesh points on top of it:
-img = imread('D:\Github\data\ibug\helen\testset\30427236_1.jpg');
+% Project all vertices to 2D:
+points_2d = mesh.vertices * (render_params.viewport*render_params.projection*render_params.modelview)';
+% Display the image and plot the projected mesh points on top of it:
 figure(3);
-imshow(img);
+imshow(image);
 hold on;
-plot(points_2d(:,1), points_2d(:,2), 'g.');
+plot(points_2d(:, 1), points_2d(:, 2), 'g.');
 % We can also plot the landmarks the mesh was fitted to:
-plot(landmarks(:,1), landmarks(:,2), 'ro');
+plot(landmarks(:, 1), landmarks(:, 2), 'ro');
 
 
 %% Just a helper function to read ibug .pts landmarks from a file:

--- a/matlab/include/mexplus_eigen.hpp
+++ b/matlab/include/mexplus_eigen.hpp
@@ -1,7 +1,7 @@
 /*
  * eos - A 3D Morphable Model fitting library written in modern C++11/14.
  *
- * File: matlab/private/test.cpp
+ * File: matlab/include/mexplus_eigen.hpp
  *
  * Copyright 2016 Patrik Huber
  *
@@ -17,17 +17,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mexplus.h"
+#pragma once
+
+#ifndef MEXPLUS_EIGEN_HPP_
+#define MEXPLUS_EIGEN_HPP_
+
+#include "mexplus/mxarray.h"
 
 #include "Eigen/Core"
 
 #include "mex.h"
-//#include "matrix.h"
-
-#include <iostream>
 
 namespace mexplus {
-// Define template specialisations for Eigen::MatrixXd:
+
+/**
+ * @brief Define a template specialisation for Eigen::MatrixXd for ... .
+ *
+ * Todo: Documentation.
+ */
 template<>
 mxArray* MxArray::from(const Eigen::MatrixXd& eigen_matrix) {
 	const int num_rows = static_cast<int>(eigen_matrix.rows());
@@ -48,6 +55,11 @@ mxArray* MxArray::from(const Eigen::MatrixXd& eigen_matrix) {
 	return out_array.release();
 };
 
+/**
+ * @brief Define a template specialisation for Eigen::MatrixXd for ... .
+ *
+ * Todo: Documentation.
+ */
 template<>
 void MxArray::to(const mxArray* in_array, Eigen::MatrixXd* eigen_matrix)
 {
@@ -79,69 +91,6 @@ void MxArray::to(const mxArray* in_array, Eigen::MatrixXd* eigen_matrix)
 	*eigen_matrix = eigen_map;
 };
 
-} // namespace mexplus
+} /* namespace mexplus */
 
-
-using namespace mexplus;
-
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
-{
-	using std::vector;
-	// Check for proper number of input and output arguments:
-	mexPrintf("nlhs: %d, nrhs: %d\n", nlhs, nrhs);
-	if (nrhs != 2) {
-		mexErrMsgIdAndTxt("eos:example:nargin", "Example requires two input arguments.");
-	}
-	else if (nlhs >= 2) { // 'nlhs >= 1' means no output argument apparently?
-		mexErrMsgIdAndTxt("eos:example:nargout", "Example requires zero or one output arguments.");
-	}
-
-	InputArguments input(nrhs, prhs, 2);
-	double vin1 = input.get<double>(0);
-	// Matlab stores col-wise in memory - hence the entry of the second row comes first
-	auto vin2 = input.get<vector<double>>(1);
-/*	auto test = input[1];
-	MxArray mxa(test);
-	auto ndim = mxa.dimensionSize();
-	auto nrows = mxa.dimensions()[0];
-	auto ncols = mxa.dimensions()[1];
-	Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>> em(vin2.data(), 2, 3);
-	// ==> Yes, now I can put exactly this in the MxArray namespace!
-	std::stringstream ss;
-	ss << em;
-	std::string msg = ss.str();
-*/
-	//auto x = MxArray::Numeric<double>(2, 2);
-
-	auto asdf = input.get<Eigen::MatrixXd>(1);
-	std::stringstream ss2;
-	ss2 << asdf;
-	std::string msg2 = ss2.str();
-
-	OutputArguments output(nlhs, plhs, 1);
-	output.set(0, asdf);
-
-	//double *vin1, *vin2;
-	//vin1 = (double*)mxGetPr(prhs[0]);
-	//vin2 = (double*)mxGetPr(prhs[1]);
-	mexPrintf("%f, %f\n", vin1, vin2[0]);
-};
-
-void func()
-{
-	int x = 4;
-};
-
-int func1()
-{
-	return 5;
-};
-
-class MyClass
-{
-public:
-	MyClass() = default;
-	int test() {
-		return 6;
-	};
-};
+#endif /* MEXPLUS_EIGEN_HPP_ */

--- a/matlab/include/mexplus_eos_types.hpp
+++ b/matlab/include/mexplus_eos_types.hpp
@@ -1,0 +1,151 @@
+/*
+ * eos - A 3D Morphable Model fitting library written in modern C++11/14.
+ *
+ * File: matlab/include/mexplus_eos_types.hpp
+ *
+ * Copyright 2016 Patrik Huber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifndef MEXPLUS_EOS_TYPES_HPP_
+#define MEXPLUS_EOS_TYPES_HPP_
+
+#include "eos/render/Mesh.hpp"
+
+#include "mexplus/mxarray.h"
+
+#include "glm/vec4.hpp"
+
+#include "Eigen/Core"
+
+#include "mex.h"
+
+/**
+ * Todo: Add a doxygen file comment? See opencv cereal?
+ */
+
+namespace mexplus {
+
+// We have an overload for vector<tvec4<float>> directly because otherwise a cell
+// will be used. However, such overload for tvec4<float> can be added without affecting
+// this one, this overload takes precedence!
+// Todo: Numeric<float> instead?
+template<>
+mxArray* MxArray::from(const std::vector<glm::tvec2<float>>& vec)
+{
+	MxArray out_array(MxArray::Numeric<double>(vec.size(), 2));
+	for (int r = 0; r < vec.size(); ++r) {
+		for (int c = 0; c < 2; ++c) {
+			out_array.set(r, c, vec[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+template<>
+mxArray* MxArray::from(const std::vector<glm::tvec3<float>>& vec)
+{
+	MxArray out_array(MxArray::Numeric<double>(vec.size(), 3));
+	for (int r = 0; r < vec.size(); ++r) {
+		for (int c = 0; c < 3; ++c) {
+			out_array.set(r, c, vec[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+template<>
+mxArray* MxArray::from(const std::vector<glm::tvec4<float>>& vec)
+{
+	MxArray out_array(MxArray::Numeric<double>(vec.size(), 4));
+	for (int r = 0; r < vec.size(); ++r) {
+		for (int c = 0; c < 4; ++c) {
+			out_array.set(r, c, vec[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+// This is for tvi and tci - return them as matrix, not as cell-array.
+template<>
+mxArray* MxArray::from(const std::vector<std::array<int, 3>>& vec)
+{
+	MxArray out_array(MxArray::Numeric<int>(vec.size(), 3));
+	for (int r = 0; r < vec.size(); ++r) {
+		for (int c = 0; c < 3; ++c) {
+			out_array.set(r, c, vec[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+/**
+ * @brief Define a template specialisation for ... .
+ *
+ * Todo: Documentation.
+ */
+template<>
+mxArray* MxArray::from(const eos::render::Mesh& mesh) {
+
+	MxArray out_array(MxArray::Struct());
+	out_array.set("vertices", mesh.vertices);
+	out_array.set("colors", mesh.colors);
+	out_array.set("texcoords", mesh.texcoords);
+	out_array.set("tvi", mesh.tvi);
+	out_array.set("tci", mesh.tci);
+
+	return out_array.release();
+};
+
+/**
+ * @brief Define a template specialisation for Eigen::MatrixXd for ... .
+ *
+ * Todo: Documentation.
+ */
+/*
+template<>
+void MxArray::to(const mxArray* in_array, Eigen::MatrixXd* eigen_matrix)
+{
+	MxArray array(in_array);
+
+	if (array.dimensionSize() > 2)
+	{
+		mexErrMsgIdAndTxt("eos:matlab", "Given array has > 2 dimensions. Can only create 2-dimensional matrices (and vectors).");
+	}
+
+	if (array.dimensionSize() == 1 || array.dimensionSize() == 0)
+	{
+		mexErrMsgIdAndTxt("eos:matlab", "Given array has 0 or 1 dimensions but we expected a 2-dimensional matrix (or row/column vector).");
+		// Even when given a single value dimensionSize() is 2, with n=m=1. When does this happen?
+	}
+
+	if (!array.isDouble())
+	{
+		mexErrMsgIdAndTxt("eos:matlab", "Trying to create a Eigen::MatrixXd in C++, but the given data is not of type double.");
+	}
+
+	// We can be sure now that the array is 2-dimensional (or 0, but then we're screwed anyway)
+	auto nrows = array.dimensions()[0]; // or use array.rows()
+	auto ncols = array.dimensions()[1];
+
+	// I think I can just use Eigen::Matrix, not a Map - the Matrix c'tor that we call creates a Map anyway?
+	Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>> eigen_map(array.getData<double>(), nrows, ncols);
+	// Not sure that's alright - who owns the data? I think as it is now, everything points to the data in the mxArray owned by Matlab, but I'm not 100% sure.
+	*eigen_matrix = eigen_map;
+};
+*/
+} /* namespace mexplus */
+
+#endif /* MEXPLUS_EOS_TYPES_HPP_ */

--- a/matlab/include/mexplus_eos_types.hpp
+++ b/matlab/include/mexplus_eos_types.hpp
@@ -38,11 +38,26 @@
 #include "mex.h"
 
 /**
- * Todo: Add a doxygen file comment? See opencv cereal?
+ * @file
+ * @brief Contains mexplus template specialisations to convert eos data
+ * structures into Matlab.
+ *
+ * Note 1: These all copy the data, which I believe might be necessary, since
+ * Matlab may unload a mex module (with all its allocated data) at any given
+ * time.
+ * Note 2: They all return double vectors and matrices, even when the data given
+ * are floats. We can think about changing that if it's a speed issue, however,
+ * I think double is Matlab's default data type.
  */
 
 namespace mexplus {
 
+/**
+ * @brief Converts a glm::tquat<float> to a Matlab vector.
+ *
+ * @param[in] quat The quaternion to convert.
+ * @return An 1x4 Matlab vector.
+ */
 template<>
 mxArray* MxArray::from(const glm::tquat<float>& quat)
 {
@@ -53,6 +68,12 @@ mxArray* MxArray::from(const glm::tquat<float>& quat)
 	return out_array.release();
 };
 
+/**
+ * @brief Converts a glm::tmat4x4<float> to a Matlab matrix.
+ *
+ * @param[in] mat The matrix to convert.
+ * @return A 4x4 Matlab matrix.
+ */
 template<>
 mxArray* MxArray::from(const glm::tmat4x4<float>& mat)
 {
@@ -65,63 +86,117 @@ mxArray* MxArray::from(const glm::tmat4x4<float>& mat)
 	return out_array.release();
 };
 
-// We have an overload for vector<tvec4<float>> directly because otherwise a cell
-// will be used. However, such overload for tvec4<float> can be added without affecting
-// this one, this overload takes precedence!
-// Todo: Numeric<float> instead?
+/**
+ * @brief Converts an std::vector of glm::tvec2<float> to a Matlab matrix.
+ *
+ * This function converts a whole vector of vec2's to an n x 2 Matlab matrix,
+ * where n is data.size(). It is mainly used to pass texture coordinates of
+ * a Mesh to Matlab.
+ *
+ * We specialise for std::vector<glm::tvec2<float>> directly (and not for
+ * glm::tvec2<float>) because otherwise a cell array of vec2's would be
+ * generated. Luckily, even if a tvec2 specialisation was to exist too,
+ * this one would take precedence to convert a vector<tvec2>.
+ *
+ * @param[in] data The data to convert.
+ * @return An n x 2 Matlab matrix.
+ */
 template<>
-mxArray* MxArray::from(const std::vector<glm::tvec2<float>>& vec)
+mxArray* MxArray::from(const std::vector<glm::tvec2<float>>& data)
 {
-	MxArray out_array(MxArray::Numeric<double>(vec.size(), 2));
-	for (int r = 0; r < vec.size(); ++r) {
+	MxArray out_array(MxArray::Numeric<double>(data.size(), 2));
+	for (int r = 0; r < data.size(); ++r) {
 		for (int c = 0; c < 2; ++c) {
-			out_array.set(r, c, vec[r][c]);
-		}
-	}
-	return out_array.release();
-};
-
-template<>
-mxArray* MxArray::from(const std::vector<glm::tvec3<float>>& vec)
-{
-	MxArray out_array(MxArray::Numeric<double>(vec.size(), 3));
-	for (int r = 0; r < vec.size(); ++r) {
-		for (int c = 0; c < 3; ++c) {
-			out_array.set(r, c, vec[r][c]);
-		}
-	}
-	return out_array.release();
-};
-
-template<>
-mxArray* MxArray::from(const std::vector<glm::tvec4<float>>& vec)
-{
-	MxArray out_array(MxArray::Numeric<double>(vec.size(), 4));
-	for (int r = 0; r < vec.size(); ++r) {
-		for (int c = 0; c < 4; ++c) {
-			out_array.set(r, c, vec[r][c]);
-		}
-	}
-	return out_array.release();
-};
-
-// This is for tvi and tci - return them as matrix, not as cell-array.
-template<>
-mxArray* MxArray::from(const std::vector<std::array<int, 3>>& vec)
-{
-	MxArray out_array(MxArray::Numeric<int>(vec.size(), 3));
-	for (int r = 0; r < vec.size(); ++r) {
-		for (int c = 0; c < 3; ++c) {
-			out_array.set(r, c, vec[r][c]);
+			out_array.set(r, c, data[r][c]);
 		}
 	}
 	return out_array.release();
 };
 
 /**
- * @brief Define a template specialisation for ... .
+ * @brief Converts an std::vector of glm::tvec3<float> to a Matlab matrix.
  *
- * Todo: Documentation.
+ * This function converts a whole vector of vec3's to an n x 3 Matlab matrix,
+ * where n is data.size(). It is mainly used to pass vertex colour data of
+ * a Mesh to Matlab.
+ *
+ * See template<> mxArray* MxArray::from(const std::vector<glm::tvec2<float>>&)
+ * for more details.
+ *
+ * @param[in] data The data to convert.
+ * @return An n x 3 Matlab matrix.
+ */
+template<>
+mxArray* MxArray::from(const std::vector<glm::tvec3<float>>& data)
+{
+	MxArray out_array(MxArray::Numeric<double>(data.size(), 3));
+	for (int r = 0; r < data.size(); ++r) {
+		for (int c = 0; c < 3; ++c) {
+			out_array.set(r, c, data[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+/**
+ * @brief Converts an std::vector of glm::tvec4<float> to a Matlab matrix.
+ *
+ * This function converts a whole vector of vec4's to an n x 4 Matlab matrix,
+ * where n is data.size(). It is mainly used to pass vertex data of a Mesh
+ * to Matlab.
+ *
+ * See template<> mxArray* MxArray::from(const std::vector<glm::tvec2<float>>&)
+ * for more details.
+ *
+ * @param[in] data The data to convert.
+ * @return An n x 4 Matlab matrix.
+ */
+template<>
+mxArray* MxArray::from(const std::vector<glm::tvec4<float>>& data)
+{
+	MxArray out_array(MxArray::Numeric<double>(data.size(), 4));
+	for (int r = 0; r < data.size(); ++r) {
+		for (int c = 0; c < 4; ++c) {
+			out_array.set(r, c, data[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+/**
+ * @brief Converts an std::vector of std::array<int, 3> to a Matlab matrix.
+ *
+ * This function converts a whole vector of array<int, 3>'s to an n x 3 Matlab
+ * matrix, where n is data.size(). It is mainly used to pass triangle indices
+ * data of a Mesh to Matlab.
+ *
+ * We specialise for vector<array<int, 3>> directly (and not for array<int, 3>)
+ * because otherwise a cell array of arrays would be generated. Luckily, even
+ * if an array<int, 3> specialisation was to exist too, this one would take
+ * precedence to convert a vector<array<int, 3>>.
+ *
+ * @param[in] data The data to convert.
+ * @return An n x 3 Matlab matrix.
+ */
+template<>
+mxArray* MxArray::from(const std::vector<std::array<int, 3>>& data)
+{
+	MxArray out_array(MxArray::Numeric<int>(data.size(), 3));
+	for (int r = 0; r < data.size(); ++r) {
+		for (int c = 0; c < 3; ++c) {
+			out_array.set(r, c, data[r][c]);
+		}
+	}
+	return out_array.release();
+};
+
+/**
+ * @brief Define a template specialisation for eos::render::Mesh.
+ *
+ * This converts an eos::render::Mesh into a Matlab struct.
+ * 
+ * @param[in] mesh The Mesh that will be returned to Matlab.
+ * @return An mxArray containing a Matlab struct with all vertex, colour, texcoords and triangle data.
  */
 template<>
 mxArray* MxArray::from(const eos::render::Mesh& mesh) {
@@ -137,9 +212,12 @@ mxArray* MxArray::from(const eos::render::Mesh& mesh) {
 };
 
 /**
- * @brief Define a template specialisation for ... .
+ * @brief Define a template specialisation for eos::fitting::RenderingParameters.
  *
- * Todo: Documentation.
+ * This converts an eos::fitting::RenderingParameters into a Matlab struct.
+ * 
+ * @param[in] rendering_parameters The RenderingParameters that will be returned to Matlab.
+ * @return An mxArray containing a Matlab struct with all required parameters.
  */
 template<>
 mxArray* MxArray::from(const eos::fitting::RenderingParameters& rendering_parameters) {

--- a/matlab/include/mexplus_eos_types.hpp
+++ b/matlab/include/mexplus_eos_types.hpp
@@ -158,10 +158,24 @@ mxArray* MxArray::from(const eos::fitting::RenderingParameters& rendering_parame
 			return "unknown";
 		}
 	}();
+
+	// Since we don't expose get_opencv_viewport(), and Matlab doesn't have glm::project()
+	// anyway, we'll make a 4x4 viewport matrix available. Matlab seems to have the same
+	// convention than OpenCV (top-left is the image origin).
+	auto viewport = eos::fitting::get_opencv_viewport(rendering_parameters.get_screen_width(), rendering_parameters.get_screen_height());
+	glm::mat4x4 viewport_matrix; // Identity matrix
+	viewport_matrix[0][0] = 0.5f * viewport[2];
+	viewport_matrix[3][0] = 0.5f * viewport[2] + viewport[0];
+	viewport_matrix[1][1] = 0.5f * viewport[3];
+	viewport_matrix[3][1] = 0.5f * viewport[3] + viewport[1];
+	viewport_matrix[2][2] = 0.5f;
+	viewport_matrix[3][2] = 0.5f;
+
 	out_array.set("camera_type", camera_type);
 	out_array.set("rotation_quaternion", rendering_parameters.get_rotation());
 	out_array.set("modelview", rendering_parameters.get_modelview());
 	out_array.set("projection", rendering_parameters.get_projection());
+	out_array.set("viewport", viewport_matrix);
 	out_array.set("screen_width", rendering_parameters.get_screen_width());
 	out_array.set("screen_height", rendering_parameters.get_screen_height());
 

--- a/matlab/private/test.cpp
+++ b/matlab/private/test.cpp
@@ -19,26 +19,112 @@
  */
 #include "mexplus.h"
 
+#include "Eigen/Core"
+
 #include "mex.h"
 //#include "matrix.h"
 
 #include <iostream>
 
+namespace mexplus {
+// Define template specialisations for Eigen::MatrixXd:
+template<>
+mxArray* MxArray::from(const Eigen::MatrixXd& eigen_matrix) {
+	const int num_rows = static_cast<int>(eigen_matrix.rows());
+	const int num_cols = static_cast<int>(eigen_matrix.cols());
+	MxArray out_array(MxArray::Numeric<double>(num_rows, num_cols));
+
+	// This might not copy the data but it's evil and probably really dangerous!!!:
+	//mxSetData(const_cast<mxArray*>(matrix.get()), (void*)value.data());
+
+	// This copies the data. But I suppose it makes sense that we copy the data when we go
+	// from C++ to Matlab, since Matlab can unload the C++ mex module at any time I think.
+	// Loop is column-wise
+	for (int c = 0; c < num_cols; ++c) {
+		for (int r = 0; r < num_rows; ++r) {
+			out_array.set(r, c, eigen_matrix(r, c));
+		}
+	}
+	return out_array.release();
+};
+
+template<>
+void MxArray::to(const mxArray* in_array, Eigen::MatrixXd* eigen_matrix)
+{
+	MxArray array(in_array);
+
+	if (array.dimensionSize() > 2)
+	{
+		mexErrMsgIdAndTxt("eos:matlab", "Given array has > 2 dimensions. Can only create 2-dimensional matrices (and vectors).");
+	}
+
+	if (array.dimensionSize() == 1 || array.dimensionSize() == 0)
+	{
+		mexErrMsgIdAndTxt("eos:matlab", "Given array has 0 or 1 dimensions but we expected a 2-dimensional matrix (or row/column vector).");
+		// Even when given a single value dimensionSize() is 2, with n=m=1. When does this happen?
+	}
+
+	if (!array.isDouble())
+	{
+		mexErrMsgIdAndTxt("eos:matlab", "Trying to create a Eigen::MatrixXd in C++, but the given data is not of type double.");
+	}
+
+	// We can be sure now that the array is 2-dimensional (or 0, but then we're screwed anyway)
+	auto nrows = array.dimensions()[0]; // or use array.rows()
+	auto ncols = array.dimensions()[1];
+
+	// I think I can just use Eigen::Matrix, not a Map - the Matrix c'tor that we call creates a Map anyway?
+	Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>> eigen_map(array.getData<double>(), nrows, ncols);
+	// Not sure that's alright - who owns the data? I think as it is now, everything points to the data in the mxArray owned by Matlab, but I'm not 100% sure.
+	*eigen_matrix = eigen_map;
+};
+
+} // namespace mexplus
+
+
+using namespace mexplus;
+
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
+	using std::vector;
 	// Check for proper number of input and output arguments:
 	mexPrintf("nlhs: %d, nrhs: %d\n", nlhs, nrhs);
 	if (nrhs != 2) {
-		mexErrMsgIdAndTxt("eos:example:nargin", "example requires two input arguments.");
+		mexErrMsgIdAndTxt("eos:example:nargin", "Example requires two input arguments.");
 	}
-	else if (nlhs >= 1) {
-		mexErrMsgIdAndTxt("eos:example:nargout", "example requires no output argument.");
+	else if (nlhs >= 2) { // 'nlhs >= 1' means no output argument apparently?
+		mexErrMsgIdAndTxt("eos:example:nargout", "Example requires zero or one output arguments.");
 	}
 
-	double *vin1, *vin2;
-	vin1 = (double*)mxGetPr(prhs[0]);
-	vin2 = (double*)mxGetPr(prhs[1]);
-	mexPrintf("%f, %f\n", *vin1, *vin2);
+	InputArguments input(nrhs, prhs, 2);
+	double vin1 = input.get<double>(0);
+	// Matlab stores col-wise in memory - hence the entry of the second row comes first
+	auto vin2 = input.get<vector<double>>(1);
+/*	auto test = input[1];
+	MxArray mxa(test);
+	auto ndim = mxa.dimensionSize();
+	auto nrows = mxa.dimensions()[0];
+	auto ncols = mxa.dimensions()[1];
+	Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>> em(vin2.data(), 2, 3);
+	// ==> Yes, now I can put exactly this in the MxArray namespace!
+	std::stringstream ss;
+	ss << em;
+	std::string msg = ss.str();
+*/
+	//auto x = MxArray::Numeric<double>(2, 2);
+
+	auto asdf = input.get<Eigen::MatrixXd>(1);
+	std::stringstream ss2;
+	ss2 << asdf;
+	std::string msg2 = ss2.str();
+
+	OutputArguments output(nlhs, plhs, 1);
+	output.set(0, asdf);
+
+	//double *vin1, *vin2;
+	//vin1 = (double*)mxGetPr(prhs[0]);
+	//vin2 = (double*)mxGetPr(prhs[1]);
+	mexPrintf("%f, %f\n", vin1, vin2[0]);
 };
 
 void func()

--- a/matlab/private/test.cpp
+++ b/matlab/private/test.cpp
@@ -1,0 +1,61 @@
+/*
+ * eos - A 3D Morphable Model fitting library written in modern C++11/14.
+ *
+ * File: matlab/private/test.cpp
+ *
+ * Copyright 2016 Patrik Huber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mexplus.h"
+
+#include "mex.h"
+//#include "matrix.h"
+
+#include <iostream>
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+	// Check for proper number of input and output arguments:
+	mexPrintf("nlhs: %d, nrhs: %d\n", nlhs, nrhs);
+	if (nrhs != 2) {
+		mexErrMsgIdAndTxt("eos:example:nargin", "example requires two input arguments.");
+	}
+	else if (nlhs >= 1) {
+		mexErrMsgIdAndTxt("eos:example:nargout", "example requires no output argument.");
+	}
+
+	double *vin1, *vin2;
+	vin1 = (double*)mxGetPr(prhs[0]);
+	vin2 = (double*)mxGetPr(prhs[1]);
+	mexPrintf("%f, %f\n", *vin1, *vin2);
+};
+
+void func()
+{
+	int x = 4;
+};
+
+int func1()
+{
+	return 5;
+};
+
+class MyClass
+{
+public:
+	MyClass() = default;
+	int test() {
+		return 6;
+	};
+};


### PR DESCRIPTION
This adds Matlab bindings to the fitting function `fit_shape_and_pose(...)`, which means the fitting can be run from Matlab. A mesh and rendering_parameters (pose) is returned.

If `GENERATE_MATLAB_BINDINGS` is set in CMake, the respective mex and .m files are generated and installed.