### PR TITLE
Enabling GENERATE_PYTHON_BINDINGS on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - C_COMPILER=gcc-5 CXX_COMPILER=g++-5
   - C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
 
-python:
-  - "3.5"
+#python:
+#  - "3.5"
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -18,12 +18,12 @@ before_install:
   - sudo apt-get install gcc-5 g++-5 -y
   - sudo apt-get install clang-3.8 -y
   - sudo apt-get install libboost-all-dev libeigen3-dev libopencv-dev -y
-  - sudo apt-get install python3 python3-dev
+#  - sudo apt-get install python3 python3-dev
 
 before_script:
   - mkdir build
   - cd build
-  - cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DBUILD_EXAMPLES=on -DBUILD_UTILS=on -DGENERATE_PYTHON_BINDINGS=on ..
+  - cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DBUILD_EXAMPLES=on -DBUILD_UTILS=on -DGENERATE_PYTHON_BINDINGS=on -DPYTHON_EXECUTABLE=`which python3.5` ..
 
 script:
   - make VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ env:
   - C_COMPILER=gcc-5 CXX_COMPILER=g++-5
   - C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
 
-#python:
-#  - "3.5"
-
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
@@ -18,7 +15,6 @@ before_install:
   - sudo apt-get install gcc-5 g++-5 -y
   - sudo apt-get install clang-3.8 -y
   - sudo apt-get install libboost-all-dev libeigen3-dev libopencv-dev -y
-#  - sudo apt-get install python3 python3-dev
 
 before_script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,12 @@ before_install:
   - sudo apt-get install gcc-5 g++-5 -y
   - sudo apt-get install clang-3.8 -y
   - sudo apt-get install libboost-all-dev libeigen3-dev libopencv-dev -y
+  - sudo apt-get install python3 python3-dev
 
 before_script:
   - mkdir build
   - cd build
-  - cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DBUILD_EXAMPLES=on -DBUILD_UTILS=on ..
+  - cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DBUILD_EXAMPLES=on -DBUILD_UTILS=on -DGENERATE_PYTHON_BINDINGS=on ..
 
 script:
   - make VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
   - C_COMPILER=gcc-5 CXX_COMPILER=g++-5
   - C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
 
+python:
+  - "3.5"
+
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -


### PR DESCRIPTION
The travis trusty image has python3.5 installed, but in /opt/ somewhere. I couldn't get it to use the system python3.5, although the `python3` is already installed.