### PR TITLE
Change python on travis to 3.6 to avoid error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - ../cmake-3.8.2-Linux-x86_64/bin/cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DEOS_BUILD_EXAMPLES=on -DEOS_BUILD_UTILS=on -DEOS_GENERATE_PYTHON_BINDINGS=on -DPYTHON_EXECUTABLE=`which python3.6` ..
+  - ../cmake-3.8.2-Linux-x86_64/bin/cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DEOS_BUILD_EXAMPLES=on -DEOS_BUILD_UTILS=on -DEOS_GENERATE_PYTHON_BINDINGS=on ..
 
 script:
   - make VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
   - sudo apt-get install libboost-all-dev libopencv-dev -y
   - wget https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
   - tar -xvzf cmake-3.8.2-Linux-x86_64.tar.gz
+  - which python
+  - which python3
+  - which python3.6
 
 before_script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
 
 before_install:
+  - pyenv global system 3.6
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
@@ -17,18 +18,11 @@ before_install:
   - sudo apt-get install libboost-all-dev libopencv-dev -y
   - wget https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
   - tar -xvzf cmake-3.8.2-Linux-x86_64.tar.gz
-  - which python
-  - which python3
-  - which python3.6
-  - pyenv global system 3.6
-  - which python
-  - which python3
-  - which python3.6
 
 before_script:
   - mkdir build
   - cd build
-  - ../cmake-3.8.2-Linux-x86_64/bin/cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DEOS_BUILD_EXAMPLES=on -DEOS_BUILD_UTILS=on -DEOS_GENERATE_PYTHON_BINDINGS=on ..
+  - ../cmake-3.8.2-Linux-x86_64/bin/cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DEOS_BUILD_EXAMPLES=on -DEOS_BUILD_UTILS=on -DEOS_GENERATE_PYTHON_BINDINGS=on -DPYTHON_EXECUTABLE=`which python3.6` ..
 
 script:
   - make VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
 
 before_install:
-  - pyenv global system 3.6
+  - pyenv global system 3.6 # Workaround for travis-ci/issues/8363
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ dist: trusty
 
 language: cpp
 
-python:
-  - 3.6
-
 env:
   - C_COMPILER=gcc-7 CXX_COMPILER=g++-7
   - C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
@@ -20,6 +17,10 @@ before_install:
   - sudo apt-get install libboost-all-dev libopencv-dev -y
   - wget https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
   - tar -xvzf cmake-3.8.2-Linux-x86_64.tar.gz
+  - which python
+  - which python3
+  - which python3.6
+  - pyenv global system 3.6
   - which python
   - which python3
   - which python3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ dist: trusty
 
 language: cpp
 
+python:
+  - 3.6
+
 env:
   - C_COMPILER=gcc-7 CXX_COMPILER=g++-7
   - C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
 
 before_install:
-  - pyenv global system 3.5 # Workaround for travis-ci/issues/8363
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
   - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
@@ -22,7 +24,7 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - ../cmake-3.8.2-Linux-x86_64/bin/cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DEOS_BUILD_EXAMPLES=on -DEOS_BUILD_UTILS=on -DEOS_GENERATE_PYTHON_BINDINGS=on -DPYTHON_EXECUTABLE=`which python3.5` ..
+  - ../cmake-3.8.2-Linux-x86_64/bin/cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DEOS_BUILD_EXAMPLES=on -DEOS_BUILD_UTILS=on -DEOS_GENERATE_PYTHON_BINDINGS=on -DPYTHON_EXECUTABLE=`which python3.6` ..
 
 script:
   - make VERBOSE=1


### PR DESCRIPTION
I've tried various fixes like:
```
python:
  - 3.6
```
in the .travis.yml file, but none worked (see travis-ci/travis-ci/issues/8363). Keeping `pyenv global system` and simply changing the version to 3.6 worked though.