### PR TITLE
added an include to fit-model-multi.cpp

### DIFF
--- a/examples/fit-model-multi.cpp
+++ b/examples/fit-model-multi.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 #include <iostream>
 #include <fstream>
+#include <string>
 
 using namespace eos;
 namespace po = boost::program_options;


### PR DESCRIPTION
Needed #include <string> for fit-model-multi.cpp.  Without it I got a runtime error under Visual Studio 2015.