### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Ignore (optional) configuration files with user-specific paths:
 initial_cache.cmake
 setup.cfg
+# Ignore build directories for building in this directory
+build/
+install/


### PR DESCRIPTION
Ignore build/ and install/ so one can build with
/eos/build$ cmake .. -DCMAKE_INSTALL_PREFIX=../install/
Therefore it's easier to be managed as a submodule.