### PR TITLE
Ceres nonlinear refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 # Ignore (optional) configuration files with user-specific paths:
 initial_cache.cmake
 setup.cfg
+
+# Mac specific files
+*.DS_Store
+
+# IntelliJ IDEA files
+.idea/
+cmake-build-*
+
+# Testing data files
+examples/data
+

--- a/examples/fit-model-ceres.cpp
+++ b/examples/fit-model-ceres.cpp
@@ -18,60 +18,239 @@
  * limitations under the License.
  */
 #define GLM_FORCE_UNRESTRICTED_GENTYPE
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#include "boost/filesystem.hpp"
+#include "boost/program_options.hpp"
+#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/highgui/highgui.hpp"
+
 #include "eos/core/Landmark.hpp"
 #include "eos/core/LandmarkMapper.hpp"
 #include "eos/core/read_pts_landmarks.hpp"
 #include "eos/fitting/ceres_nonlinear.hpp"
-#include "eos/fitting/contour_correspondence.hpp"
-#include "eos/fitting/fitting.hpp"
 #include "eos/morphablemodel/Blendshape.hpp"
 
-#include "Eigen/Core"
-
-#include "glm/ext.hpp"
-#include "glm/glm.hpp"
-
-#include "ceres/ceres.h"
-#include "ceres/cubic_interpolation.h"
-#include "ceres/rotation.h"
-
-#include "opencv2/core/core.hpp"
-#include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/highgui/highgui.hpp"
-
-#include "boost/filesystem.hpp"
-#include "boost/program_options.hpp"
-
-#include <chrono>
-#include <iostream>
-#include <vector>
 
 using namespace eos;
-using namespace glm;
 using namespace ceres;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 using eos::core::Landmark;
 using eos::core::LandmarkCollection;
+using eos::core::IndexedLandmark;
+using eos::core::IndexedLandmarkCollection;
 using cv::Mat;
 using Eigen::Vector2f;
-using std::cout;
-using std::endl;
-using std::string;
-using std::vector;
 
-// print a vector:
-template <typename T>
-std::ostream& operator<<(std::ostream& out, const std::vector<T>& v)
-{
-    if (!v.empty())
-    {
+
+#ifndef EOS_CERES_EXAMPLE_USE_PERSPECTIVE
+#define EOS_CERES_EXAMPLE_USE_PERSPECTIVE true
+#endif
+
+#ifndef EOS_CERES_EXAMPLE_SHAPES_NUM
+#define EOS_CERES_EXAMPLE_SHAPES_NUM 63
+#endif
+
+#ifndef EOS_CERES_EXAMPLE_BLENDSHAPES_NUM
+#define EOS_CERES_EXAMPLE_BLENDSHAPES_NUM 6
+#endif
+
+#ifndef EOS_CERES_EXAMPLE_COLOR_COEFFS_NUM
+#define EOS_CERES_EXAMPLE_COLOR_COEFFS_NUM 10
+#endif
+
+
+namespace eos {
+    namespace ceres_example {
+        struct HelpCallException : public std::exception {
+            const char *what() const noexcept override {
+                return "User called help";
+            }
+        };
+
+        struct CliArguments {
+            fs::path blendshapesfile,
+                     contourfile,
+                     imagefile,
+                     landmarksfile,
+                     mappingsfile,
+                     modelfile,
+                     outputfile;
+        };
+
+
+        CliArguments parse_cli_arguments(int argc, char *argv[]) {
+            fs::path blendshapesfile,
+                     contourfile,
+                     imagefile,
+                     landmarksfile,
+                     mappingsfile,
+                     modelfile,
+                     outputfile;
+
+            try {
+                po::options_description desc("Allowed options");
+                // clang-format off
+                desc.add_options()
+                        ("help,h", "display the help message")
+                        ("model,m", po::value<fs::path>(&modelfile)->required()->default_value(
+                                "../share/sfm_shape_3448.bin"),
+                         "a Morphable Model, containing a shape and albedo model, stored as cereal BinaryArchive")
+                        ("blendshapes,b", po::value<fs::path>(&blendshapesfile)->required()->default_value(
+                                "../share/expression_blendshapes_3448.bin"),
+                         "file with blendshapes")
+                        ("image,i", po::value<fs::path>(&imagefile)->required()->default_value("data/image_0010.png"),
+                         "an input image")
+                        ("landmarks,l",
+                         po::value<fs::path>(&landmarksfile)->required()->default_value("data/image_0010.pts"),
+                         "2D landmarks for the image, in ibug .pts format")
+                        ("mapping,p",
+                         po::value<fs::path>(&mappingsfile)->required()->default_value("../share/ibug_to_sfm.txt"),
+                         "landmark identifier to model vertex number mapping")
+                        ("model-contour,c",
+                         po::value<fs::path>(&contourfile)->required()->default_value(
+                                 "../share/sfm_model_contours.json"),
+                         "file with model contour indices")
+                        ("output,o", po::value<fs::path>(&outputfile)->required()->default_value("out"),
+                         "basename for the output obj file");
+                // clang-format on
+                po::variables_map vm;
+                po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
+                if (vm.count("help")) {
+                    std::cout << "Usage: fit-model-ceres [options]" << std::endl;
+                    std::cout << desc;
+                    throw HelpCallException();
+                }
+                po::notify(vm);
+            } catch (const po::error &e) {
+                std::string error_text = static_cast<std::string>("Error while parsing command-line arguments: ") +
+                                         e.what() + '\n';
+                std::cout << error_text;
+                std::cout << "Use --help to display a list of options." << std::endl;
+                throw std::invalid_argument(error_text);
+            }
+
+            return CliArguments {blendshapesfile,
+                                 contourfile,
+                                 imagefile,
+                                 landmarksfile,
+                                 mappingsfile,
+                                 modelfile,
+                                 outputfile};
+        }
+
+        struct FittingData {
+            fitting::ModelContour model_contour;
+            fitting::ContourLandmarks ibug_contour;
+            Mat image;
+            LandmarkCollection<Vector2f> landmarks;
+            morphablemodel::MorphableModel morphable_model;
+            core::LandmarkMapper landmark_mapper;
+            std::vector<morphablemodel::Blendshape> blendshapes;
+        };
+
+
+        FittingData read_fitting_data(const std::string &blendshapesfile,
+                                      const std::string &contourfile,
+                                      const std::string &imagefile,
+                                      const std::string &landmarksfile,
+                                      const std::string &mappingsfile,
+                                      const std::string &modelfile,
+                                      const std::string &outputfile) {
+            fitting::ModelContour model_contour;
+            fitting::ContourLandmarks ibug_contour;
+            if (contourfile.empty()) {
+                model_contour = fitting::ModelContour();
+                ibug_contour = fitting::ContourLandmarks();
+            } else {
+                model_contour = fitting::ModelContour::load(contourfile);
+                try {
+                    ibug_contour = fitting::ContourLandmarks::load(mappingsfile);
+                } catch (const std::runtime_error &e) {
+                    const std::string error_text =
+                            static_cast<std::string>("Error reading the contour mappings file: ") +
+                            e.what() + '\n';
+                    std::cout << error_text << std::flush;
+                    throw std::runtime_error(error_text);
+                }
+            }
+
+            Mat image = cv::imread(imagefile);
+            LandmarkCollection<Vector2f> landmarks;
+            try {
+                landmarks = core::read_pts_landmarks(landmarksfile);
+            } catch (const std::runtime_error &e) {
+                const std::string error_text = static_cast<std::string>("Error reading the landmarks: ") +
+                                               e.what() + '\n';
+                std::cout << error_text << std::flush;
+                throw std::runtime_error(error_text);
+            }
+            morphablemodel::MorphableModel morphable_model;
+            try {
+                morphable_model = morphablemodel::load_model(modelfile);
+            } catch (const std::runtime_error &e) {
+                const std::string error_text = static_cast<std::string>("Error loading the Morphable Model: ") +
+                                               e.what() + '\n';
+                std::cout << error_text << std::flush;
+                throw std::runtime_error(error_text);
+            }
+
+            // Note: Actually it's a required argument, so it'll never be empty.
+            core::LandmarkMapper landmark_mapper =
+                    mappingsfile.empty() ? core::LandmarkMapper() : core::LandmarkMapper(mappingsfile);
+
+            std::vector<morphablemodel::Blendshape> blendshapes =
+                    morphablemodel::load_blendshapes(blendshapesfile);
+
+            return FittingData {model_contour,
+                                ibug_contour,
+                                image,
+                                landmarks,
+                                morphable_model,
+                                landmark_mapper,
+                                blendshapes};
+        }
+
+        template<typename LandmarkType>
+        void draw_landmarks(Mat &image, const IndexedLandmarkCollection<LandmarkType> &landmarks,
+                            const cv::Scalar &color = {0.0, 255.0, 255.0}) {
+            for (const auto &landmark : landmarks) {
+                cv::rectangle(image, cv::Point2d(landmark.coordinates[0] - 2.0f, landmark.coordinates[1] - 2.0f),
+                              cv::Point2d(landmark.coordinates[0] + 2.0f, landmark.coordinates[1] + 2.0f), color);
+            }
+        }
+
+        template<typename LandmarkType>
+        void draw_mesh_vertices(Mat &image, const core::Mesh &mesh,
+                                const IndexedLandmarkCollection<LandmarkType> &landmarks,
+                                const glm::dmat4x4& tr_matrix, const glm::dmat4x4& projection_matrix,
+                                const glm::dvec4& viewport, const cv::Scalar &color = {0.0f, 0.0f, 255.0f}) {
+            for (const auto &landmark : landmarks) {
+                const auto &vertex = mesh.vertices[landmark.model_index];
+                glm::dvec3 point_3d(vertex[0], vertex[1], vertex[2]); // The 3D model point
+                glm::dvec3 projected_point = glm::project(point_3d, tr_matrix, projection_matrix, viewport);
+                cv::circle(image, cv::Point2d(projected_point.x, projected_point.y), 3, color); // red
+            }
+        }
+    }
+}
+
+
+template<typename T, std::size_t N>
+std::ostream& operator<<(std::ostream& out, const std::array<T, N>& a) {
+    if (!a.empty()) {
         out << '[';
-        std::copy(v.begin(), v.end(), std::ostream_iterator<T>(out, ", "));
+        std::copy(a.begin(), a.end(), std::ostream_iterator<T>(out, ", "));
         out << "\b\b]";
     }
     return out;
 };
+
 
 /**
  * Single and multi-image non-linear model fitting with Ceres example.
@@ -83,406 +262,159 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T>& v)
  */
 int main(int argc, char* argv[])
 {
-    fs::path modelfile, isomapfile, imagefile, landmarksfile, mappingsfile, contourfile, blendshapesfile,
-        outputfile;
-    try
-    {
-        po::options_description desc("Allowed options");
-        // clang-format off
-        desc.add_options()
-            ("help,h", "display the help message")
-            ("model,m", po::value<fs::path>(&modelfile)->required()->default_value("../share/sfm_3448.bin"),
-                "a Morphable Model, containing a shape and albedo model, stored as cereal BinaryArchive")
-            ("blendshapes,b", po::value<fs::path>(&blendshapesfile)->required()->default_value("../share/expression_blendshapes_3448.bin"),
-                "file with blendshapes")
-            ("image,i", po::value<fs::path>(&imagefile)->required()->default_value("data/image_0010.png"),
-                "an input image")
-            ("landmarks,l", po::value<fs::path>(&landmarksfile)->required()->default_value("data/image_0010.pts"),
-                "2D landmarks for the image, in ibug .pts format")
-            ("mapping,p", po::value<fs::path>(&mappingsfile)->required()->default_value("../share/ibug_to_sfm.txt"),
-                "landmark identifier to model vertex number mapping")
-            ("model-contour,c", po::value<fs::path>(&contourfile)->required()->default_value("../share/sfm_model_contours.json"),
-                "file with model contour indices")
-            ("output,o", po::value<fs::path>(&outputfile)->required()->default_value("out"),
-                "basename for the output obj file");
-        // clang-format on
-        po::variables_map vm;
-        po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
-        if (vm.count("help"))
-        {
-            cout << "Usage: fit-model-ceres [options]" << endl;
-            cout << desc;
-            return EXIT_SUCCESS;
-        }
-        po::notify(vm);
-    } catch (const po::error& e)
-    {
-        cout << "Error while parsing command-line arguments: " << e.what() << endl;
-        cout << "Use --help to display a list of options." << endl;
+    // Read cli arguments
+    ceres_example::CliArguments cli_arguments;
+    try {
+        cli_arguments = ceres_example::parse_cli_arguments(argc, argv);
+    } catch (const ceres_example::HelpCallException& e) {
+        return EXIT_SUCCESS;
+    } catch (const std::invalid_argument& e) {
         return EXIT_FAILURE;
     }
+
+    // Read all data from disk
+    ceres_example::FittingData fitting_data;
+    try {
+        fitting_data = ceres_example::read_fitting_data(cli_arguments.blendshapesfile.string(),
+                                                        cli_arguments.contourfile.string(),
+                                                        cli_arguments.imagefile.string(),
+                                                        cli_arguments.landmarksfile.string(),
+                                                        cli_arguments.mappingsfile.string(),
+                                                        cli_arguments.modelfile.string(),
+                                                        cli_arguments.outputfile.string());
+    } catch (const std::runtime_error& e) {
+        return EXIT_FAILURE;
+    }
+
+    const auto& model_contour = fitting_data.model_contour;
+    const auto& ibug_contour = fitting_data.ibug_contour;
+    const auto& image = fitting_data.image;
+    const auto& morphable_model = fitting_data.morphable_model;
+    const auto& landmark_mapper = fitting_data.landmark_mapper;
+    const auto& blendshapes = fitting_data.blendshapes;
+
+    // These will be the 2D image points and their corresponding 3D vertex id's used for the fitting
+    auto& landmarks = fitting_data.landmarks;
+
+    auto landmarks_definitions = morphable_model.get_landmark_definitions();
+    auto* landmarks_definitions_ptr = landmarks_definitions.has_value() ? &landmarks_definitions.value() : nullptr;
+    auto indexed_landmarks = landmark_mapper.get_indexed_landmarks(landmarks, landmarks_definitions_ptr);
 
     google::InitGoogleLogging(argv[0]); // Ceres logging initialisation
-
-    fitting::ModelContour model_contour =
-        contourfile.empty() ? fitting::ModelContour() : fitting::ModelContour::load(contourfile.string());
-
-    fitting::ContourLandmarks ibug_contour;
-    try
-    {
-        ibug_contour = fitting::ContourLandmarks::load(mappingsfile.string());
-    } catch (const std::runtime_error& e)
-    {
-        cout << "Error reading the contour mappings file: " << e.what() << endl;
-        return EXIT_FAILURE;
-    }
-
-    // Load the image, landmarks, LandmarkMapper and the Morphable Model:
-    Mat image = cv::imread(imagefile.string());
-    LandmarkCollection<Eigen::Vector2f> landmarks;
-    try
-    {
-        landmarks = core::read_pts_landmarks(landmarksfile.string());
-    } catch (const std::runtime_error& e)
-    {
-        cout << "Error reading the landmarks: " << e.what() << endl;
-        return EXIT_FAILURE;
-    }
-    morphablemodel::MorphableModel morphable_model;
-    try
-    {
-        morphable_model = morphablemodel::load_model(modelfile.string());
-    } catch (const std::runtime_error& e)
-    {
-        cout << "Error loading the Morphable Model: " << e.what() << endl;
-        return EXIT_FAILURE;
-    }
-
-    // Note: Actually it's a required argument, so it'll never be empty.
-    core::LandmarkMapper landmark_mapper =
-        mappingsfile.empty() ? core::LandmarkMapper() : core::LandmarkMapper(mappingsfile.string());
-
-    std::vector<eos::morphablemodel::Blendshape> blendshapes =
-        eos::morphablemodel::load_blendshapes(blendshapesfile.string());
-
-    // Draw the loaded landmarks:
-    Mat outimg = image.clone();
-    for (const auto& lm : landmarks)
-    {
-        cv::rectangle(outimg, cv::Point2f(lm.coordinates[0] - 2.0f, lm.coordinates[1] - 2.0f),
-                      cv::Point2f(lm.coordinates[0] + 2.0f, lm.coordinates[1] + 2.0f), {255, 0, 0});
-    }
-
-    constexpr bool use_perspective = false;
-
-    // These will be the 2D image points and their corresponding 3D vertex id's used for the fitting:
-    vector<Vector2f> image_points; // the 2D landmark points
-    vector<int> vertex_indices; // their corresponding vertex indices
-
-    // Sub-select all the landmarks which we have a mapping for (i.e. that are defined in the 3DMM):
-    for (int i = 0; i < landmarks.size(); ++i)
-    {
-        auto converted_name = landmark_mapper.convert(landmarks[i].name);
-        if (!converted_name)
-        { // no mapping defined for the current landmark
-            continue;
-        }
-        int vertex_idx = std::stoi(converted_name.value());
-        vertex_indices.emplace_back(vertex_idx);
-        image_points.emplace_back(landmarks[i].coordinates);
-    }
+    std::stringstream fitting_log;
 
     // Estimate the camera (pose) from the 2D - 3D point correspondences
-    std::stringstream fitting_log;
     auto start = std::chrono::steady_clock::now();
 
-    std::vector<double> camera_rotation; // Quaternion, [w x y z]. Todo: Actually, use std::array for all of these.
-    camera_rotation.resize(4); // initialises with zeros
-    camera_rotation[0] = 1.0;
-    std::vector<double> camera_translation_and_intrinsics;
-    constexpr int num_cam_trans_intr_params = use_perspective ? 4 : 3;
-    // Parameters for the orthographic projection: [t_x, t_y, frustum_scale]
-    // And perspective projection: [t_x, t_y, t_z, fov].
-    // Origin is assumed at center of image, and no lens distortions.
-    // Note: Actually, we estimate the model-view matrix and not the camera position. But one defines the
-    // other.
-    camera_translation_and_intrinsics.resize(num_cam_trans_intr_params); // initialises with zeros
-    if (use_perspective)
-    {
-        camera_translation_and_intrinsics[2] = -400.0;              // Move the model back (along the -z axis)
-        camera_translation_and_intrinsics[3] = glm::radians(45.0f); // fov
-    } else
-    {
-        camera_translation_and_intrinsics[2] = 110.0; // frustum_scale
-    }
+    auto model_fitter = fitting::ModelFitter<EOS_CERES_EXAMPLE_SHAPES_NUM,
+                                             EOS_CERES_EXAMPLE_BLENDSHAPES_NUM,
+                                             EOS_CERES_EXAMPLE_COLOR_COEFFS_NUM>(&morphable_model, &blendshapes);
+    auto camera = fitting::PerspectiveCameraParameters(image.cols, image.rows);
+    model_fitter.add_camera_cost_function(camera, indexed_landmarks);
+    model_fitter.block_shapes_fitting();
+    model_fitter.block_blendshapes_fitting();
+    model_fitter.block_fov_fitting(camera, 60.0);
 
-    std::vector<double> shape_coefficients;
-    shape_coefficients.resize(10); // Todo: Currently, the value '10' is hard-coded everywhere. Make it dynamic.
-    std::vector<double> blendshape_coefficients;
-    blendshape_coefficients.resize(6);
+    auto solver_summary = model_fitter.solve();
 
-    Problem camera_costfunction;
-    for (int i = 0; i < image_points.size(); ++i)
-    {
-        CostFunction* cost_function =
-            new AutoDiffCostFunction<fitting::LandmarkCost, 2 /* num residuals */,
-                                     4 /* camera rotation (quaternion) */,
-                                     num_cam_trans_intr_params /* camera translation & fov/frustum_scale */,
-                                     10 /* shape-coeffs */, 6 /* bs-coeffs */>(
-                new fitting::LandmarkCost(morphable_model.get_shape_model(), blendshapes, image_points[i],
-                                          vertex_indices[i], image.cols, image.rows, use_perspective));
-
-        camera_costfunction.AddResidualBlock(cost_function, NULL, &camera_rotation[0],
-                                             &camera_translation_and_intrinsics[0], &shape_coefficients[0],
-                                             &blendshape_coefficients[0]);
-    }
-    camera_costfunction.SetParameterBlockConstant(&shape_coefficients[0]); // keep the shape constant
-    camera_costfunction.SetParameterBlockConstant(&blendshape_coefficients[0]);
-    if (use_perspective)
-    {
-        camera_costfunction.SetParameterUpperBound(
-            &camera_translation_and_intrinsics[0], 2,
-            -std::numeric_limits<double>::epsilon()); // t_z has to be negative
-        camera_costfunction.SetParameterLowerBound(&camera_translation_and_intrinsics[0], 3,
-                                                   0.01); // fov in radians, must be > 0
-    } else
-    {
-        camera_costfunction.SetParameterLowerBound(&camera_translation_and_intrinsics[0], 2,
-                                                   1.0); // frustum_scale must be > 0
-    }
-    QuaternionParameterization* camera_fit_quaternion_parameterisation = new QuaternionParameterization;
-    camera_costfunction.SetParameterization(&camera_rotation[0], camera_fit_quaternion_parameterisation);
-
-    Solver::Options solver_options;
-    solver_options.linear_solver_type = ITERATIVE_SCHUR;
-    solver_options.num_threads = 8;
-    solver_options.num_linear_solver_threads = 8; // only SPARSE_SCHUR can use this
-    solver_options.minimizer_progress_to_stdout = true;
-    // solver_options.max_num_iterations = 100;
-    Solver::Summary solver_summary;
-    Solve(solver_options, &camera_costfunction, &solver_summary);
-    std::cout << solver_summary.BriefReport() << "\n";
     auto end = std::chrono::steady_clock::now();
+    // Log fitting report
+    std::cout << solver_summary.BriefReport() << std::endl;
 
     // Draw the mean-face landmarks projected using the estimated camera:
     // Construct the rotation & translation (model-view) matrices, projection matrix, and viewport:
-    glm::dquat estimated_rotation(camera_rotation[0], camera_rotation[1], camera_rotation[2],
-                                  camera_rotation[3]);
-    auto rot_mtx = glm::mat4_cast(estimated_rotation);
-    const double aspect = static_cast<double>(image.cols) / image.rows;
-    auto get_translation_matrix = [](auto&& camera_translation_and_intrinsics, auto&& use_perspective) {
-        if (use_perspective)
-        {
-            return glm::translate(glm::dvec3(camera_translation_and_intrinsics[0],
-                                             camera_translation_and_intrinsics[1],
-                                             camera_translation_and_intrinsics[2]));
-        } else
-        {
-            return glm::translate(
-                glm::dvec3(camera_translation_and_intrinsics[0], camera_translation_and_intrinsics[1], 0.0));
-        }
-    };
-    auto get_projection_matrix = [](auto&& camera_translation_and_intrinsics, auto&& aspect,
-                                    auto&& use_perspective) {
-        if (use_perspective)
-        {
-            const auto& focal = camera_translation_and_intrinsics[3];
-            return glm::perspective(focal, aspect, 0.1, 1000.0);
-        } else
-        {
-            const auto& frustum_scale = camera_translation_and_intrinsics[2];
-            return glm::ortho(-1.0 * aspect * frustum_scale, 1.0 * aspect * frustum_scale,
-                              -1.0 * frustum_scale, 1.0 * frustum_scale);
-        }
-    };
-    auto t_mtx = get_translation_matrix(camera_translation_and_intrinsics, use_perspective);
-    auto projection_mtx = get_projection_matrix(camera_translation_and_intrinsics, aspect, use_perspective);
-    const glm::dvec4 viewport(0, image.rows, image.cols, -image.rows); // OpenCV convention
 
-    auto mean_mesh = morphable_model.get_mean();
-    for (auto idx : vertex_indices)
-    {
-        glm::dvec3 point_3d(mean_mesh.vertices[idx][0], mean_mesh.vertices[idx][1],
-                            mean_mesh.vertices[idx][2]); // The 3D model point
-        glm::dvec3 projected_point = glm::project(point_3d, t_mtx * rot_mtx, projection_mtx, viewport);
-        cv::circle(outimg, cv::Point2f(projected_point.x, projected_point.y), 3, {0.0f, 0.0f, 255.0f}); // red
-    }
-    for (const auto& lm : image_points)
-    {
-        cv::circle(outimg, cv::Point2f(lm(0), lm(1)), 3,
-                   {0.0f, 255.0f, 255.0f}); // yellow: subset of the detected LMs that we use
-    }
-    auto euler_angles = glm::eulerAngles(estimated_rotation); // returns [P, Y, R]
-    fitting_log << "Pose fit with mean shape:\tYaw " << glm::degrees(euler_angles[1]) << ", Pitch "
-                << glm::degrees(euler_angles[0]) << ", Roll " << glm::degrees(euler_angles[2])
-                << "; t & f: " << camera_translation_and_intrinsics << '\n';
-    fitting_log << "Ceres took: "
-                << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms.\n";
+    Mat outimg = image.clone();
+    ceres_example::draw_mesh_vertices(outimg, morphable_model.get_mean(), indexed_landmarks,
+                                      camera.calculate_translation_matrix() * camera.calculate_rotation_matrix(),
+                                      camera.calculate_projection_matrix(), camera.get_viewport());
+    ceres_example::draw_landmarks(outimg, indexed_landmarks);
+
+    auto camera_euler_rotation = camera.get_euler_rotation();
+    fitting_log << "Pose fit with mean shape:\tYaw " << glm::degrees(camera_euler_rotation[1])
+                << ", Pitch " << glm::degrees(camera_euler_rotation[0]) << ", Roll "
+                << glm::degrees(camera_euler_rotation[2])
+                << "; t & f: " << camera.translation_and_intrinsics << '\n'
+                << "Ceres took: "
+                << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms." << std::endl;
+
+    const auto& outputfile = cli_arguments.outputfile;
+    auto new_path = outputfile.parent_path() / fs::path(outputfile.stem().string() + "_pos_only");
+    new_path.replace_extension(".png");
+    cv::imwrite(new_path.string(), outimg);
 
     // Contour fitting:
-    // These are the additional contour-correspondences we're going to find and then use:
-    vector<Vector2f> image_points_contour; // the 2D landmark points
-    vector<int> vertex_indices_contour; // their corresponding 3D vertex indices
-    // For each 2D contour landmark, get the corresponding 3D vertex point and vertex id:
-    std::tie(image_points_contour, std::ignore, vertex_indices_contour) =
-        fitting::get_contour_correspondences(landmarks, ibug_contour, model_contour,
-                                             glm::degrees(euler_angles[1]), morphable_model.get_mean(),
-                                             t_mtx * rot_mtx, projection_mtx, viewport);
-    using eos::fitting::concat;
-    vertex_indices = concat(vertex_indices, vertex_indices_contour);
-    image_points = concat(image_points, image_points_contour);
+    if (!fitting_data.ibug_contour.empty()) {
+        auto indexed_contours = model_fitter.estimate_contours(camera,
+                                                               fitting_data.ibug_contour, fitting_data.model_contour,
+                                                               landmarks);
+        indexed_landmarks.insert(indexed_landmarks.end(), indexed_contours.begin(), indexed_contours.end());
+        ceres_example::draw_landmarks(outimg, indexed_landmarks); // yellow: subset of the detected LMs that we use
+                                                                  // (draw with contour landmarks)
+    }
 
     // Full fitting - Estimate shape and pose, given the previous pose estimate:
     start = std::chrono::steady_clock::now();
-    Problem fitting_costfunction;
-    // Landmark constraint:
-    for (int i = 0; i < image_points.size(); ++i)
-    {
-        CostFunction* cost_function =
-            new AutoDiffCostFunction<fitting::LandmarkCost, 2 /* num residuals */,
-                                     4 /* camera rotation (quaternion) */,
-                                     num_cam_trans_intr_params /* camera translation & focal length */,
-                                     10 /* shape-coeffs */, 6 /* bs-coeffs */>(
-                new fitting::LandmarkCost(morphable_model.get_shape_model(), blendshapes, image_points[i],
-                                          vertex_indices[i], image.cols, image.rows, use_perspective));
-        fitting_costfunction.AddResidualBlock(cost_function, NULL, &camera_rotation[0],
-                                              &camera_translation_and_intrinsics[0], &shape_coefficients[0],
-                                              &blendshape_coefficients[0]);
-    }
-    // Shape prior:
-    CostFunction* shape_prior_cost =
-        new AutoDiffCostFunction<fitting::PriorCost, 10 /* num residuals */, 10 /* shape-coeffs */>(
-            new fitting::PriorCost(10, 35.0));
-    fitting_costfunction.AddResidualBlock(shape_prior_cost, NULL, &shape_coefficients[0]);
-    for (int i = 0; i < 10; ++i)
-    {
-        fitting_costfunction.SetParameterLowerBound(&shape_coefficients[0], i, -3.0);
-        fitting_costfunction.SetParameterUpperBound(&shape_coefficients[0], i, 3.0);
-    }
-    // Prior and constraints on blendshapes:
-    CostFunction* blendshapes_prior_cost =
-        new AutoDiffCostFunction<fitting::PriorCost, 6 /* num residuals */, 6 /* bs-coeffs */>(
-            new fitting::PriorCost(6, 10.0));
-    fitting_costfunction.AddResidualBlock(blendshapes_prior_cost, NULL, &blendshape_coefficients[0]);
-    fitting_costfunction.SetParameterLowerBound(&blendshape_coefficients[0], 0, 0.0);
-    fitting_costfunction.SetParameterLowerBound(&blendshape_coefficients[0], 1, 0.0);
-    fitting_costfunction.SetParameterLowerBound(&blendshape_coefficients[0], 2, 0.0);
-    fitting_costfunction.SetParameterLowerBound(&blendshape_coefficients[0], 3, 0.0);
-    fitting_costfunction.SetParameterLowerBound(&blendshape_coefficients[0], 4, 0.0);
-    fitting_costfunction.SetParameterLowerBound(&blendshape_coefficients[0], 5, 0.0);
-    // Some constraints on the camera translation and fov/scale:
-    if (use_perspective)
-    {
-        fitting_costfunction.SetParameterUpperBound(
-            &camera_translation_and_intrinsics[0], 2,
-            -std::numeric_limits<double>::epsilon()); // t_z has to be negative
-        fitting_costfunction.SetParameterLowerBound(&camera_translation_and_intrinsics[0], 3,
-                                                    0.01); // fov in radians, must be > 0
-    } else
-    {
-        fitting_costfunction.SetParameterLowerBound(&camera_translation_and_intrinsics[0], 2,
-                                                    1.0); // frustum_scale must be > 0
-    }
 
-    QuaternionParameterization* full_fit_quaternion_parameterisation = new QuaternionParameterization;
-    fitting_costfunction.SetParameterization(&camera_rotation[0], full_fit_quaternion_parameterisation);
+    model_fitter.reset_problem();
+    model_fitter.add_camera_cost_function(camera, indexed_landmarks);
+    model_fitter.block_fov_fitting(camera, 60.0);
+
+    model_fitter.add_shape_prior_cost_function();
+    model_fitter.add_blendshape_prior_cost_function();
 
     // Colour model fitting (this needs a Morphable Model with colour (albedo) model, see note above main()):
-    if (!morphable_model.has_color_model())
-    {
-        cout << "Error: The MorphableModel used does not contain a colour (albedo) model. ImageCost requires "
-                "a model that contains a colour PCA model. You may want to use the full Surrey Face Model or "
-                "remove this section.";
-        return EXIT_FAILURE;
-    }
-    std::vector<double> colour_coefficients;
-    colour_coefficients.resize(10);
-    // Add a residual for each vertex:
-    for (int i = 0; i < morphable_model.get_shape_model().get_data_dimension() / 3; ++i)
-    {
-        CostFunction* cost_function =
-            new AutoDiffCostFunction<fitting::ImageCost, 3 /* Residuals: [R, G, B] */,
-                                     4 /* camera rotation (quaternion) */,
-                                     num_cam_trans_intr_params /* camera translation & focal length */,
-                                     10 /* shape-coeffs */, 6 /* bs-coeffs */, 10 /* colour coeffs */>(
-                new fitting::ImageCost(morphable_model, blendshapes, image, i, use_perspective));
-        fitting_costfunction.AddResidualBlock(cost_function, NULL, &camera_rotation[0],
-                                              &camera_translation_and_intrinsics[0], &shape_coefficients[0],
-                                              &blendshape_coefficients[0], &colour_coefficients[0]);
-    }
-    // Prior for the colour coefficients:
-    CostFunction* colour_prior_cost =
-        new AutoDiffCostFunction<fitting::PriorCost, 10 /* num residuals */, 10 /* colour-coeffs */>(
-            new fitting::PriorCost(10, 35.0));
-    fitting_costfunction.AddResidualBlock(colour_prior_cost, NULL, &colour_coefficients[0]);
-    for (int i = 0; i < 10; ++i)
-    {
-        fitting_costfunction.SetParameterLowerBound(&colour_coefficients[0], i, -3.0);
-        fitting_costfunction.SetParameterUpperBound(&colour_coefficients[0], i, 3.0);
+    Eigen::VectorXf color_instance;
+    darray<EOS_CERES_EXAMPLE_COLOR_COEFFS_NUM> colour_coefficients;
+    if (morphable_model.has_color_model()) {
+        // Add a residual for each vertex:
+        model_fitter.add_image_cost_function(camera, image);
+        model_fitter.add_image_prior_cost_function();
+
+        color_instance = morphable_model.get_color_model().draw_sample(colour_coefficients);
+    } else {
+        std::cout << "The MorphableModel used does not contain a colour (albedo) model. No ImageCost will be applied."
+                  << std::endl;
+        color_instance = Eigen::VectorXf();
     }
 
-    // Set different options for the full fitting:
-    /*	solver_options.linear_solver_type = ceres::ITERATIVE_SCHUR;
-            //solver_options.linear_solver_type = ceres::DENSE_QR;
-            //solver_options.minimizer_type = ceres::TRUST_REGION; // default I think
-            //solver_options.minimizer_type = ceres::LINE_SEARCH;
-            solver_options.num_threads = 8;
-            solver_options.num_linear_solver_threads = 8; // only SPARSE_SCHUR can use this
-            solver_options.minimizer_progress_to_stdout = true;
-            solver_options.max_num_iterations = 100;
-            */
-    Solve(solver_options, &fitting_costfunction, &solver_summary);
-    std::cout << solver_summary.BriefReport() << "\n";
+    solver_summary = model_fitter.solve();
+    std::cout << solver_summary.BriefReport() << std::endl;
     end = std::chrono::steady_clock::now();
 
     // Draw the landmarks projected using all estimated parameters:
     // Construct the rotation & translation (model-view) matrices, projection matrix, and viewport:
-    estimated_rotation =
-        glm::dquat(camera_rotation[0], camera_rotation[1], camera_rotation[2], camera_rotation[3]);
-    rot_mtx = glm::mat4_cast(estimated_rotation);
-    t_mtx = get_translation_matrix(camera_translation_and_intrinsics, use_perspective);
-    projection_mtx = get_projection_matrix(camera_translation_and_intrinsics, aspect, use_perspective);
 
-    auto vectord_to_vectorf = [](const std::vector<double>& vec) {
-        return std::vector<float>(std::begin(vec), std::end(vec));
-    };
-    auto blendshape_coeffs_float = vectord_to_vectorf(blendshape_coefficients);
-    Eigen::VectorXf shape_ceres =
-        morphable_model.get_shape_model().draw_sample(shape_coefficients) +
-        to_matrix(blendshapes) *
-            Eigen::Map<const Eigen::VectorXf>(blendshape_coeffs_float.data(), blendshape_coeffs_float.size());
+    auto points = model_fitter.calculate_estimated_points_positions();
+
     core::Mesh mesh = morphablemodel::sample_to_mesh(
-        shape_ceres, morphable_model.get_color_model().draw_sample(colour_coefficients),
+        points, color_instance,
         morphable_model.get_shape_model().get_triangle_list(),
-        morphable_model.get_color_model().get_triangle_list(), morphable_model.get_texture_coordinates());
-    for (auto idx : vertex_indices)
-    {
-        glm::dvec3 point_3d(mesh.vertices[idx][0], mesh.vertices[idx][1],
-                            mesh.vertices[idx][2]); // The 3D model point
-        glm::dvec3 projected_point = glm::project(point_3d, t_mtx * rot_mtx, projection_mtx, viewport);
-        cv::circle(outimg, cv::Point2f(projected_point.x, projected_point.y), 3,
-                   {0.0f, 76.0f, 255.0f}); // orange
-    }
-    for (const auto& lm : image_points)
-    {
-        cv::circle(outimg, cv::Point2f(lm(0), lm(1)), 3,
-                   {0.0f, 255.0f,
-                    255.0f}); // yellow: subset of the detected LMs that we use (including contour landmarks)
-    }
+        morphable_model.get_color_model().get_triangle_list(),
+        morphable_model.get_texture_coordinates(),
+        morphable_model.get_texture_triangle_indices());
 
-    estimated_rotation =
-        glm::dquat(camera_rotation[0], camera_rotation[1], camera_rotation[2], camera_rotation[3]);
-    euler_angles = glm::eulerAngles(estimated_rotation); // returns [P, Y, R]
-    fitting_log << "Final fit:\t\t\tYaw " << glm::degrees(euler_angles[1]) << ", Pitch "
-                << glm::degrees(euler_angles[0]) << ", Roll " << glm::degrees(euler_angles[2])
-                << "; t & f: " << camera_translation_and_intrinsics << '\n';
+    ceres_example::draw_mesh_vertices(outimg, morphable_model.get_mean(), indexed_landmarks,
+                                      camera.calculate_translation_matrix() * camera.calculate_rotation_matrix(),
+                                      camera.calculate_projection_matrix(), camera.get_viewport(),
+                                      {0.0f, 76.0f, 255.0f}); // orange
+
+    camera_euler_rotation = camera.get_euler_rotation();
+    fitting_log << "Final fit:\t\t\tYaw " << glm::degrees(camera_euler_rotation[1]) << ", Pitch "
+                << glm::degrees(camera_euler_rotation[0]) << ", Roll "
+                << glm::degrees(camera_euler_rotation[2])
+                << "; t & f: " << camera.translation_and_intrinsics << std::endl;
     fitting_log << "Ceres took: "
-                << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms.\n";
+                << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms." << std::endl;
 
-    cout << fitting_log.str();
+    std::cout << fitting_log.str();
 
-    outputfile.replace_extension(".obj");
-    core::write_obj(mesh, outputfile.string());
+    new_path = outputfile;
+    new_path.replace_extension(".obj");
+    core::write_obj(mesh, new_path.string());
+
+    new_path.replace_extension(".png");
+    cv::imwrite(new_path.string(), outimg);
 
     return EXIT_SUCCESS;
 }

--- a/include/eos/core/Landmark.hpp
+++ b/include/eos/core/Landmark.hpp
@@ -29,6 +29,7 @@
 namespace eos {
 namespace core {
 
+
 /**
  * @brief Representation of a landmark, consisting of a landmark name and
  * coordinates of the given type. Usually, the type would be \c Eigen::Vector2f.
@@ -41,10 +42,26 @@ struct Landmark
 };
 
 /**
+ * @brief Representation of a landmark with mesh index.
+ */
+template <class LandmarkType>
+struct IndexedLandmark: Landmark<LandmarkType>
+{
+    int model_index;  ///< Index of landmark in mesh
+};
+
+
+/**
  * @brief A trivial collection of landmarks that belong together.
  */
 template <class LandmarkType>
 using LandmarkCollection = std::vector<Landmark<LandmarkType>>;
+
+/**
+ * @brief A trivial collection of indexed landmarks that belong together.
+ */
+template <class LandmarkType>
+using IndexedLandmarkCollection = std::vector<IndexedLandmark<LandmarkType>>;
 
 /**
  * @brief Shorthand for a 2D floating point landmark type.

--- a/include/eos/core/LandmarkMapper.hpp
+++ b/include/eos/core/LandmarkMapper.hpp
@@ -22,6 +22,7 @@
 #ifndef LANDMARKMAPPER_HPP_
 #define LANDMARKMAPPER_HPP_
 
+#include "eos/core/Landmark.hpp"
 #include "eos/cpp17/optional.hpp"
 
 #include "toml.hpp"
@@ -68,7 +69,7 @@ public:
      * @param[in] filename A file with landmark mappings.
      * @throws runtime_error or toml::exception if there is an error loading the mappings from the file.
      */
-    LandmarkMapper(std::string filename)
+    LandmarkMapper(const std::string& filename)
     {
         // parse() as well as extracting the data can throw std::runtime error or toml::exception,
         // so ideally you'd want to call this c'tor within a try-catch.
@@ -102,8 +103,7 @@ public:
      *
      * @param[in] mappings A set of landmark mappings.
      */
-    LandmarkMapper(const std::unordered_map<std::string, std::string>& mappings) : landmark_mappings(mappings)
-    {};
+    LandmarkMapper(std::unordered_map<std::string, std::string> mappings) : landmark_mappings(std::move(mappings)) {};
 
     /**
      * @brief Converts the given landmark name to the mapped name.
@@ -132,6 +132,45 @@ public:
             return cpp17::nullopt;
         }
     };
+
+
+    using LandmarkDefinitions = std::unordered_map<std::string, int>;
+    /**
+     * @param landmarks landmarks to index
+     * @return new vector with landmarks for which index can be defined
+     */
+    template<typename LandmarkType>
+    auto get_indexed_landmarks(const LandmarkCollection<LandmarkType>& landmarks,
+                               const LandmarkDefinitions* const landmark_definitions = nullptr) const {
+        IndexedLandmarkCollection<LandmarkType> indexed_landmarks;
+        for (auto& landmark : landmarks) {
+            auto converted_name = this->convert(landmark.name);
+            if (!converted_name) { // no mapping defined for the current landmark
+                continue;
+            }
+
+            int vertex_idx;
+            if (landmark_definitions != nullptr)
+            {
+                const auto found_vertex_idx = landmark_definitions->find(converted_name.value());
+
+                if (found_vertex_idx != std::end(*landmark_definitions))
+                {
+                    vertex_idx = found_vertex_idx->second;
+                } else
+                {
+                    continue;
+                }
+            } else
+            {
+                vertex_idx = std::stoi(converted_name.value());
+            }
+
+            IndexedLandmark<LandmarkType> indexed_landmark {landmark.name, landmark.coordinates, vertex_idx};
+            indexed_landmarks.emplace_back(std::move(indexed_landmark));
+        }
+        return indexed_landmarks;
+    }
 
     /**
      * @brief Returns the number of loaded landmark mappings.

--- a/include/eos/core/read_pts_landmarks.hpp
+++ b/include/eos/core/read_pts_landmarks.hpp
@@ -41,13 +41,13 @@ namespace core {
  * @param[in] filename Path to a .pts file.
  * @return An ordered vector with the 68 ibug landmarks.
  */
-inline LandmarkCollection<Eigen::Vector2f> read_pts_landmarks(std::string filename)
+inline LandmarkCollection<Eigen::Vector2f> read_pts_landmarks(const std::string& filename)
 {
     using Eigen::Vector2f;
     using std::getline;
     using std::string;
     LandmarkCollection<Vector2f> landmarks;
-    landmarks.reserve(68);
+    landmarks.reserve(68);  // number of landmarks in ibug markup
 
     std::ifstream file(filename);
     if (!file)
@@ -82,7 +82,7 @@ inline LandmarkCollection<Eigen::Vector2f> read_pts_landmarks(std::string filena
         // ==> So we shift every point by 1:
         landmark.coordinates[0] -= 1.0f;
         landmark.coordinates[1] -= 1.0f;
-        landmarks.emplace_back(landmark);
+        landmarks.emplace_back(std::move(landmark));
         ++ibugId;
     }
     return landmarks;

--- a/include/eos/fitting/ceres_nonlinear.hpp
+++ b/include/eos/fitting/ceres_nonlinear.hpp
@@ -21,7 +21,10 @@
 
 #ifndef CERESNONLINEAR_HPP_
 #define CERESNONLINEAR_HPP_
+#endif
 
+#include "eos/core/Landmark.hpp"
+#include "eos/fitting/contour_correspondence.hpp"
 #include "eos/morphablemodel/MorphableModel.hpp"
 #include "eos/morphablemodel/Blendshape.hpp"
 
@@ -30,12 +33,28 @@
 #include "glm/gtc/quaternion.hpp"
 #include "glm/gtx/transform.hpp"
 
+#include "ceres/ceres.h"
 #include "ceres/cubic_interpolation.h"
+#include "ceres/problem.h"
 
+
+#ifndef EOS_CERES_USE_OPENCV
+#define EOS_CERES_USE_OPENCV true
+#endif
+
+
+#if EOS_CERES_USE_OPENCV == true
 #include "opencv2/core/core.hpp"
+#endif
 
 #include <array>
 #include <vector>
+
+
+#define get_num_cam_params(use_perspective) static_cast<std::size_t>(3) + static_cast<std::size_t>(use_perspective)
+
+template<std::size_t N> using darray = std::array<double, N>;
+
 
 namespace eos {
 namespace fitting {
@@ -43,16 +62,17 @@ namespace fitting {
 // Forward declarations:
 template <typename T>
 std::array<T, 3> get_shape_point(const morphablemodel::PcaModel& shape_model,
-                                 const std::vector<morphablemodel::Blendshape>& blendshapes, int vertex_id,
-                                 const T* const shape_coeffs, const T* const blendshape_coeffs);
+                                 const morphablemodel::Blendshapes& blendshapes, int vertex_id,
+                                 const T* const shape_coeffs, const T* const blendshape_coeffs,
+                                 std::size_t num_coeffs_fitting);
 
 template <typename T>
 std::array<T, 3> get_vertex_colour(const morphablemodel::PcaModel& colour_model, int vertex_id,
-                                   const T* const colour_coeffs);
+                                   const T* const colour_coeffs, std::size_t num_coeffs_fitting);
 
 /**
  * Cost function for a prior on the parameters.
- * 
+ *
  * Prior towards zero (0, 0...) for the parameters.
  * Note: The weight is inside the norm, so may not correspond to the "usual"
  * formulas. However I think it's equivalent up to a scaling factor, but it
@@ -67,7 +87,7 @@ struct PriorCost
      * @param[in] num_variables Number of variables that the parameter vector contains.
      * @param[in] weight A weight that the parameters are multiplied with.
      */
-    PriorCost(int num_variables, double weight = 1.0) : num_variables(num_variables), weight(weight){};
+    explicit PriorCost(std::size_t num_variables, double weight = 1.0) : num_variables(num_variables), weight(weight){};
 
     /**
      * Cost function implementation.
@@ -87,13 +107,14 @@ struct PriorCost
     };
 
 private:
-    int num_variables;
+    std::size_t num_variables;
     double weight;
 };
 
+
 /**
  * 2D landmark error cost function.
- * 
+ *
  * Computes the landmark reprojection error in 2D.
  * Models the cost for one landmark. The residual is 2-dim, [x, y].
  * Its input params are camera parameters, shape coefficients and
@@ -118,9 +139,9 @@ struct LandmarkCost
      * @param[in] use_perspective Whether a perspective or an orthographic projection should be used.
      */
     LandmarkCost(const morphablemodel::PcaModel& shape_model,
-                 const std::vector<morphablemodel::Blendshape>& blendshapes, Eigen::Vector2f observed_landmark,
+                 const morphablemodel::Blendshapes& blendshapes, Eigen::Vector2f observed_landmark,
                  int vertex_id, int image_width, int image_height, bool use_perspective)
-        : shape_model(shape_model), blendshapes(blendshapes), observed_landmark(observed_landmark),
+        : shape_model(shape_model), blendshapes(blendshapes), observed_landmark(std::move(observed_landmark)),
           vertex_id(vertex_id), image_width(image_width), image_height(image_height),
           aspect_ratio(static_cast<double>(image_width) / image_height), use_perspective(use_perspective){};
 
@@ -145,35 +166,35 @@ struct LandmarkCost
         using namespace glm;
         // Generate shape instance (of only one vertex id!) using current parameters and 10 shape
         // coefficients: Note: Why are we not returning a glm::tvec3<T>?
-        const auto point_arr =
-            get_shape_point<T>(shape_model, blendshapes, vertex_id, shape_coeffs, blendshape_coeffs);
+        const auto point_arr = get_shape_point<T>(shape_model, blendshapes, vertex_id, shape_coeffs,
+                                                  blendshape_coeffs, get_num_cam_params(use_perspective));
 
         // Project the point to 2D:
-        const tvec3<T> point_3d(point_arr[0], point_arr[1], point_arr[2]);
+        const auto point_3d = tvec3<T>(point_arr[0], point_arr[1], point_arr[2]);
         // I think the quaternion is always normalised because we run Ceres with QuaternionParameterization
-        const tquat<T> rot_quat(camera_rotation[0], camera_rotation[1], camera_rotation[2],
-                                camera_rotation[3]);
+        const auto rot_quat = tquat<T>(camera_rotation[0], camera_rotation[1], camera_rotation[2], camera_rotation[3]);
         // We rotate ZXY*p, which is RPY*p. I'm not sure this matrix still corresponds to RPY - probably if we
         // use glm::eulerAngles(), these are not RPY anymore and we'd have to adjust if we were to use
         // rotation matrices.
-        const tmat4x4<T> rot_mtx = glm::mat4_cast(rot_quat);
+        const auto rot_mtx = glm::mat4_cast(rot_quat);
 
         // Todo: use get_opencv_viewport() from nonlin_cam_esti.hpp.
-        const tvec4<T> viewport(0, image_height, image_width, -image_height); // OpenCV convention
+        const auto viewport = tvec4<T>(0, image_height, image_width, -image_height); // OpenCV convention
 
-        tvec3<T> projected_point; // Note: could avoid default construction by using a lambda and immediate
+        auto projected_point = tvec3<T>(); // Note: could avoid default construction by using a lambda and immediate
                                   // invocation
         if (use_perspective)
         {
             const auto t_mtx = glm::translate(tvec3<T>(camera_translation_and_intrinsics[0],
                                                        camera_translation_and_intrinsics[1],
                                                        camera_translation_and_intrinsics[2]));
-            const T& fov = camera_translation_and_intrinsics[3];
-            const auto persp_mtx = glm::perspective(fov, T(aspect_ratio), T(0.1), T(1000.0));
+            const auto& fov = camera_translation_and_intrinsics[3];
+            const auto persp_mtx = glm::perspective(fov, static_cast<T>(aspect_ratio),
+                                                    static_cast<T>(0.1), static_cast<T>(1000.0));
             projected_point = glm::project(point_3d, t_mtx * rot_mtx, persp_mtx, viewport);
         } else
         {
-            const T& frustum_scale = camera_translation_and_intrinsics[2];
+            const auto& frustum_scale = camera_translation_and_intrinsics[2];
             const auto t_mtx = glm::translate(
                 tvec3<T>(camera_translation_and_intrinsics[0], camera_translation_and_intrinsics[1],
                          0.0)); // we don't have t_z in ortho camera, it doesn't matter where it is
@@ -183,15 +204,14 @@ struct LandmarkCost
             projected_point = glm::project(point_3d, t_mtx * rot_mtx, ortho_mtx, viewport);
         }
         // Residual: Projected point minus the observed 2D landmark point
-        residual[0] = projected_point.x - T(observed_landmark[0]);
-        residual[1] = projected_point.y - T(observed_landmark[1]);
+        residual[0] = projected_point.x - static_cast<T>(observed_landmark[0]);
+        residual[1] = projected_point.y - static_cast<T>(observed_landmark[1]);
         return true;
     };
 
 private:
-    const morphablemodel::PcaModel&
-        shape_model; // Or store as pointer (non-owning) or std::reference_wrapper?
-    const std::vector<morphablemodel::Blendshape>& blendshapes;
+    const morphablemodel::PcaModel& shape_model; // Or store as pointer (non-owning) or std::reference_wrapper?
+    const morphablemodel::Blendshapes& blendshapes;
     const Eigen::Vector2f observed_landmark;
     const int vertex_id;
     const int image_width;
@@ -200,9 +220,11 @@ private:
     const bool use_perspective;
 };
 
+
+#if EOS_CERES_USE_OPENCV
 /**
  * Image error cost function (at vertex locations).
- * 
+ *
  * Measures the RGB image error between a particular vertex point of the 3D
  * model at its projected location and the observed input image.
  * Models the cost for 1 vertex. The residual is 3-dim, [r, g, b].
@@ -226,12 +248,12 @@ struct ImageCost
      * @throws std::runtime_error if the given \c image is not of type CV_8UC3.
      */
     ImageCost(const morphablemodel::MorphableModel& morphable_model,
-              const std::vector<morphablemodel::Blendshape>& blendshapes, cv::Mat image, int vertex_id,
-              bool use_perspective)
-        : morphable_model(morphable_model), blendshapes(blendshapes), image(image),
-          aspect_ratio(static_cast<double>(image.cols) / image.rows), vertex_id(vertex_id),
-          use_perspective(use_perspective)
-    {
+              const morphablemodel::Blendshapes& blendshapes, const cv::Mat& image, int vertex_id,
+              bool use_perspective): morphable_model(morphable_model), blendshapes(blendshapes),
+                                     image(image),
+                                     aspect_ratio(static_cast<double>(image.cols) / image.rows),
+                                     vertex_id(vertex_id),
+                                     use_perspective(use_perspective) {
         if (image.type() != CV_8UC3)
         {
             throw std::runtime_error("The image given to ImageCost must be of type CV_8UC3.");
@@ -270,20 +292,20 @@ struct ImageCost
         // Note: The following is all duplicated code with LandmarkCost. Fix if possible performance-wise.
         // Generate 3D shape point using the current parameters:
         const auto point_arr = get_shape_point<T>(morphable_model.get_shape_model(), blendshapes, vertex_id,
-                                                  shape_coeffs, blendshape_coeffs);
+                                                  shape_coeffs, blendshape_coeffs, get_num_cam_params(use_perspective));
 
         // Project the point to 2D:
         const tvec3<T> point_3d(point_arr[0], point_arr[1], point_arr[2]);
         // I think the quaternion is always normalised because we run Ceres with QuaternionParameterization
-        const tquat<T> rot_quat(camera_rotation[0], camera_rotation[1], camera_rotation[2],
-                                camera_rotation[3]);
+        const auto rot_quat = tquat<T>(camera_rotation[0], camera_rotation[1], camera_rotation[2],
+                                       camera_rotation[3]);
         // We rotate ZXY*p, which is RPY*p. I'm not sure this matrix still corresponds to RPY - probably if we
         // use glm::eulerAngles(), these are not RPY anymore and we'd have to adjust if we were to use
         // rotation matrices.
-        const tmat4x4<T> rot_mtx = glm::mat4_cast(rot_quat);
+        const auto rot_mtx = glm::mat4_cast(rot_quat);
 
         // Todo: use get_opencv_viewport() from nonlin_cam_esti.hpp.
-        const tvec4<T> viewport(0, image.rows, image.cols, -image.rows); // OpenCV convention
+        const auto viewport = tvec4<T>(0, image.rows, image.cols, -image.rows); // OpenCV convention
 
         tvec3<T> projected_point;
         if (use_perspective)
@@ -291,30 +313,32 @@ struct ImageCost
             const auto t_mtx = glm::translate(tvec3<T>(camera_translation_and_intrinsics[0],
                                                        camera_translation_and_intrinsics[1],
                                                        camera_translation_and_intrinsics[2]));
-            const T& focal = camera_translation_and_intrinsics[3];
-            const auto persp_mtx = glm::perspective(focal, T(aspect_ratio), T(0.1), T(1000.0));
+            const auto& focal = camera_translation_and_intrinsics[3];
+            const auto persp_mtx = glm::perspective(focal, static_cast<T>(aspect_ratio),
+                                                    static_cast<T>(0.1), static_cast<T>(1000.0));
             projected_point = glm::project(point_3d, t_mtx * rot_mtx, persp_mtx, viewport);
         } else
         {
-            const T& frustum_scale = camera_translation_and_intrinsics[2];
+            const auto& frustum_scale = camera_translation_and_intrinsics[2];
             const auto t_mtx = glm::translate(
                 tvec3<T>(camera_translation_and_intrinsics[0], camera_translation_and_intrinsics[1],
                          0.0)); // we don't have t_z in ortho camera, it doesn't matter where it is
-            const auto ortho_mtx =
-                glm::ortho(-1.0 * aspect_ratio * frustum_scale, 1.0 * aspect_ratio * frustum_scale,
-                           -1.0 * frustum_scale, 1.0 * frustum_scale);
+            const auto ortho_mtx = glm::ortho(-1.0 * aspect_ratio * frustum_scale, 1.0 * aspect_ratio * frustum_scale,
+                                              -1.0 * frustum_scale, 1.0 * frustum_scale);
             projected_point = glm::project(point_3d, t_mtx * rot_mtx, ortho_mtx, viewport);
         }
 
         // Access the image colour value at the projected pixel location, if inside the image - otherwise set
         // to (127, 127, 127) (maybe not ideal...):
-        if (projected_point.y < T(0) || projected_point.y >= T(image.rows) || projected_point.x < T(0) ||
-            projected_point.x >= T(image.cols))
+        if (projected_point.y < static_cast<T>(0) ||
+            projected_point.y >= static_cast<T>(image.rows) ||
+            projected_point.x < static_cast<T>(0) ||
+            projected_point.x >= static_cast<T>(image.cols))
         {
             // The point is outside the image.
-            residual[0] = T(127.0);
-            residual[1] = T(127.0);
-            residual[2] = T(127.0);
+            residual[0] = static_cast<T>(127.0);
+            residual[1] = static_cast<T>(127.0);
+            residual[2] = static_cast<T>(127.0);
 
             // TODO: What does interpolator.Evaluate() return in this case?
             /*	Grid2D<uchar, 3> grid(image.ptr(0), 0, image.rows, 0, image.cols);
@@ -331,32 +355,34 @@ struct ImageCost
             // Note: We could store the BiCubicInterpolator as member variable.
             // The default template arguments for Grid2D are <T, kDataDim=1, kRowMajor=true,
             // kInterleaved=true> and (except for the dimension), they're the right ones for us.
-            ceres::Grid2D<uchar, 3> grid(image.ptr(0), 0, image.rows, 0, image.cols);
-            ceres::BiCubicInterpolator<ceres::Grid2D<uchar, 3>> interpolator(grid);
-            T observed_colour[3];
+            auto grid = ceres::Grid2D<uchar, 3>(image.ptr(0), 0, image.rows, 0, image.cols);
+            auto interpolator = ceres::BiCubicInterpolator<ceres::Grid2D<uchar, 3>>(grid);
+            auto observed_colour = std::array<T, 3>();
             interpolator.Evaluate(projected_point.y, projected_point.x, &observed_colour[0]);
 
             // This probably needs to be modified if we add a light model.
-            auto model_colour = get_vertex_colour(morphable_model.get_color_model(), vertex_id, color_coeffs);
+            auto model_colour = get_vertex_colour(morphable_model.get_color_model(), vertex_id,
+                                                  color_coeffs, get_num_cam_params(use_perspective));
             // I think this returns RGB, and between [0, 1].
 
             // Residual: Vertex colour of model point minus the observed colour in the 2D image
             // observed_colour is BGR, model_colour is RGB. Residual will be RGB.
-            residual[0] = model_colour[0] * 255.0 - T(observed_colour[2]);
-            residual[1] = model_colour[1] * 255.0 - T(observed_colour[1]);
-            residual[2] = model_colour[2] * 255.0 - T(observed_colour[0]);
+            residual[0] = model_colour[0] * static_cast<T>(255.0) - static_cast<T>(observed_colour[2]);
+            residual[1] = model_colour[1] * static_cast<T>(255.0) - static_cast<T>(observed_colour[1]);
+            residual[2] = model_colour[2] * static_cast<T>(255.0) - static_cast<T>(observed_colour[0]);
         }
         return true;
     };
 
 private:
     const morphablemodel::MorphableModel& morphable_model; // Or store as pointer (non-owning) or std::reference_wrapper?
-    const std::vector<morphablemodel::Blendshape>& blendshapes;
+    const morphablemodel::Blendshapes& blendshapes;
     const cv::Mat image; // the observed image
     const double aspect_ratio;
     const int vertex_id;
     const bool use_perspective;
 };
+
 
 /**
  * Returns the 3D position of a single point of the 3D shape generated by the parameters given.
@@ -370,42 +396,41 @@ private:
  */
 template <typename T>
 std::array<T, 3> get_shape_point(const morphablemodel::PcaModel& shape_model,
-                                 const std::vector<morphablemodel::Blendshape>& blendshapes, int vertex_id,
-                                 const T* const shape_coeffs, const T* const blendshape_coeffs)
+                                 const morphablemodel::Blendshapes& blendshapes, int vertex_id,
+                                 const T* const shape_coeffs, const T* const blendshape_coeffs,
+                                 std::size_t num_coeffs_fitting)
 {
-    int num_coeffs_fitting = 10; // Todo: Should be inferred or a function parameter!
     auto mean = shape_model.get_mean_at_point(vertex_id);
     auto basis = shape_model.get_rescaled_pca_basis_at_point(vertex_id);
     // Computing Shape = mean + basis * coeffs:
     // Note: Could use an Eigen matrix with type T to see if it gives a speedup.
-    std::array<T, 3> point{T(mean[0]), T(mean[1]), T(mean[2])};
+    std::array<T, 3> point {static_cast<T>(mean[0]), static_cast<T>(mean[1]), static_cast<T>(mean[2])};
     for (int i = 0; i < num_coeffs_fitting; ++i)
     {
-        point[0] += T(basis.row(0).col(i)(0)) * shape_coeffs[i]; // it seems to be ~15% faster when these are
-                                                                 // static_cast<double>() instead of T()?
+        point[0] += static_cast<T>(basis.row(0).col(i)(0)) * shape_coeffs[i];
     }
     for (int i = 0; i < num_coeffs_fitting; ++i)
     {
-        point[1] += T(basis.row(1).col(i)(0)) * shape_coeffs[i];
+        point[1] += static_cast<T>(basis.row(1).col(i)(0)) * shape_coeffs[i];
     }
     for (int i = 0; i < num_coeffs_fitting; ++i)
     {
-        point[2] += T(basis.row(2).col(i)(0)) * shape_coeffs[i];
+        point[2] += static_cast<T>(basis.row(2).col(i)(0)) * shape_coeffs[i];
     }
     // Adding the blendshape offsets:
     // Shape = mean + basis * coeffs + blendshapes * bs_coeffs:
     auto num_blendshapes = blendshapes.size();
     for (int i = 0; i < num_blendshapes; ++i)
     {
-        point[0] += T(blendshapes[i].deformation(3 * vertex_id + 0)) * blendshape_coeffs[i];
+        point[0] += static_cast<T>(blendshapes[i].deformation(3 * vertex_id + 0)) * blendshape_coeffs[i];
     }
     for (int i = 0; i < num_blendshapes; ++i)
     {
-        point[1] += T(blendshapes[i].deformation(3 * vertex_id + 1)) * blendshape_coeffs[i];
+        point[1] += static_cast<T>(blendshapes[i].deformation(3 * vertex_id + 1)) * blendshape_coeffs[i];
     }
     for (int i = 0; i < num_blendshapes; ++i)
     {
-        point[2] += T(blendshapes[i].deformation(3 * vertex_id + 2)) * blendshape_coeffs[i];
+        point[2] += static_cast<T>(blendshapes[i].deformation(3 * vertex_id + 2)) * blendshape_coeffs[i];
     }
     return point;
 };
@@ -420,31 +445,437 @@ std::array<T, 3> get_shape_point(const morphablemodel::PcaModel& shape_model,
  */
 template <typename T>
 std::array<T, 3> get_vertex_colour(const morphablemodel::PcaModel& color_model, int vertex_id,
-                                   const T* const color_coeffs)
+                                   const T* const color_coeffs, std::size_t num_coeffs_fitting)
 {
-    int num_coeffs_fitting = 10; // Todo: Should be inferred or a function parameter!
     auto mean = color_model.get_mean_at_point(vertex_id);
     auto basis = color_model.get_rescaled_pca_basis_at_point(vertex_id);
     // Computing Colour = mean + basis * coeffs
     // Note: Could use an Eigen matrix with type T to see if it gives a speedup.
-    std::array<T, 3> point{T(mean[0]), T(mean[1]), T(mean[2])};
+    std::array<T, 3> point{static_cast<T>(mean[0]), static_cast<T>(mean[1]), static_cast<T>(mean[2])};
     for (int i = 0; i < num_coeffs_fitting; ++i)
     {
-        point[0] += T(basis.row(0).col(i)(0)) * color_coeffs[i]; // it seems to be ~15% faster when these are
-                                                                 // static_cast<double>() instead of T()?
+        point[0] += static_cast<T>(basis.row(0).col(i)(0)) * color_coeffs[i];
     }
     for (int i = 0; i < num_coeffs_fitting; ++i)
     {
-        point[1] += T(basis.row(1).col(i)(0)) * color_coeffs[i];
+        point[1] += static_cast<T>(basis.row(1).col(i)(0)) * color_coeffs[i];
     }
     for (int i = 0; i < num_coeffs_fitting; ++i)
     {
-        point[2] += T(basis.row(2).col(i)(0)) * color_coeffs[i];
+        point[2] += static_cast<T>(basis.row(2).col(i)(0)) * color_coeffs[i];
     }
     return point;
 };
 
+#endif /* EOS_CERES_USE_OPENCV */
+
+
+ceres::Solver::Options get_default_solver_options() {
+    ceres::Solver::Options solver_options;
+    solver_options.linear_solver_type = ceres::ITERATIVE_SCHUR;
+    solver_options.num_threads = 8;
+    solver_options.num_linear_solver_threads = 8; // only SPARSE_SCHUR can use this
+    solver_options.minimizer_progress_to_stdout = true;
+    solver_options.max_num_iterations = 50;
+
+    return solver_options;
+}
+
+const auto default_solver_options = get_default_solver_options();
+
+
+/*
+ * Parameters of camera
+ *
+ * They are not stored in ModelFitter to support many cameras optimization.
+ */
+template<bool use_perspective>
+struct CameraParameters {
+    CameraParameters(int image_cols, int image_rows):
+            translation_and_intrinsics(get_translation_and_intrinsics()),
+            image_cols(image_cols), image_rows(image_rows) {}
+
+    /*
+     * Return viewport for given image rows num and cols num.
+     */
+    glm::dvec4 get_viewport() const {
+        return glm::dvec4(0, image_rows, image_cols, -image_rows);
+    }
+
+    /**
+     * Cast rotation_quaternion to euler angle
+     */
+    glm::dvec3 get_euler_rotation() const {
+        return glm::eulerAngles(get_glm_rotation_quaternion());
+    }
+
+    /**
+     * Calculate translation matrix from estimated camera parameters
+     */
+    glm::dmat4x4 calculate_translation_matrix() const {
+        return glm::translate(glm::dvec3(translation_and_intrinsics[0],
+                                         translation_and_intrinsics[1],
+                                         use_perspective ? translation_and_intrinsics[2] : 0.0));
+    }
+
+    /**
+     * Calculate rotation matrix from estimated camera parameters
+     */
+    glm::dmat4x4 calculate_rotation_matrix() const {
+        return glm::mat4_cast(get_glm_rotation_quaternion());
+    }
+
+    /**
+     * Calculate projection matrix from estimated camera parameters
+     */
+    glm::dmat4x4 calculate_projection_matrix() const {
+        auto aspect = static_cast<double>(image_cols) / image_rows;
+        if (use_perspective) {
+            const auto &focal = translation_and_intrinsics[3];
+            return glm::perspective(focal, aspect, 0.1, 1000.0);
+        } else {
+            const auto &frustum_scale = translation_and_intrinsics[2];
+            return glm::ortho(-1.0 * aspect * frustum_scale, 1.0 * aspect * frustum_scale,
+                              -1.0 * frustum_scale, 1.0 * frustum_scale);
+        }
+    }
+
+    darray<4> rotation_quaternion = {1, 0, 0, 0}; // Quaternion, [w x y z].
+    darray<get_num_cam_params(use_perspective)> translation_and_intrinsics;
+    int image_cols,
+        image_rows;
+
+private:
+    /*
+     * Make array with initial camera parameters
+     *
+     * * @return std::array with 3 or 4 (for perspective projection) parameters.
+     */
+    auto get_translation_and_intrinsics() const {
+        // Parameters for the orthographic projection: [t_x, t_y, frustum_scale]
+        // And perspective projection: [t_x, t_y, t_z, fov].
+        // Origin is assumed at center of image, and no lens distortions.
+        // Note: Actually, we estimate the model-view matrix and not the camera position. But one defines the
+        // other.
+
+        darray<get_num_cam_params(use_perspective)> translation_and_intrinsics;
+        if (use_perspective) {
+            translation_and_intrinsics[2] = -400.0;              // Move the model back (along the -z axis)
+            translation_and_intrinsics[3] = glm::radians(60.0f); // fov
+        } else {
+            translation_and_intrinsics[2] = 110.0; // frustum_scale
+        }
+        return translation_and_intrinsics;
+    }
+
+
+    /**
+     * Cast rotation_quaternion to glm::quat
+     */
+    glm::dquat get_glm_rotation_quaternion() const {
+        return glm::dquat(rotation_quaternion[0], rotation_quaternion[1],
+                          rotation_quaternion[2], rotation_quaternion[3]);
+    }
+};
+
+struct PerspectiveCameraParameters: CameraParameters<true>{
+    PerspectiveCameraParameters(int image_cols, int image_rows):
+        CameraParameters<true>(image_cols, image_rows){}
+};
+
+struct OrtogonalCameraParameters: CameraParameters<false>{
+    OrtogonalCameraParameters(int image_cols, int image_rows):
+        CameraParameters<false>(image_cols, image_rows){}
+};
+
+
+/**
+ * Class that maintain all model fitting process
+ *
+ * @tparam shapes_num number of shapes of model
+ * @tparam blendshapes_num number of blendshapes of model
+ * @tparam color_coeffs_num number of color coefficients of model
+ * @tparam use_perspective will fitting use perspective projection
+ */
+template<std::size_t shapes_num, std::size_t blendshapes_num,
+#if EOS_CERES_USE_OPENCV == true
+        std::size_t color_coeffs_num
+#endif
+        >
+class ModelFitter {
+public:
+    /**
+     * @param[in] morphable_model morphable model instance
+     * @param[in] blendshapes all blendshapes to fit
+     */
+    explicit ModelFitter(const morphablemodel::MorphableModel* const morphable_model,
+                         const morphablemodel::Blendshapes* const blendshapes = nullptr):
+                         problem(std::make_unique<ceres::Problem>()), morphable_model(morphable_model),
+                         blendshapes(find_blendshapes(blendshapes)){}
+
+    /*
+     * Apply solver to overall problem
+     *
+     * @param[in] solver_options ceres solver options
+     */
+    ceres::Solver::Summary solve(const ceres::Solver::Options& solver_options = default_solver_options) {
+        // Fit position
+        ceres::Solver::Summary solver_summary;
+        ceres::Solve(solver_options, problem.get(), &solver_summary);
+
+        return solver_summary;
+    }
+
+    /**
+     * Clean up all added blocks and cost functions.
+     */
+    void reset_problem() {
+        problem = std::make_unique<ceres::Problem>();
+    }
+
+    /**
+     * Estimate contours using current fitting state and user lists of potential contours
+     *
+     * @param camera
+     * @param landmarks_contour contours in landmarks
+     * @param model_contour contours in model
+     * @param landmarks to contour search
+     * @return vector with indexed Landmarks
+     */
+    template<typename LandmarkType, bool use_perspective>
+    auto estimate_contours(const CameraParameters<use_perspective>& camera,
+                           const ContourLandmarks& landmarks_contour, const ModelContour& model_contour,
+                           const core::LandmarkCollection<LandmarkType>& landmarks) const {
+        std::vector<Eigen::Vector2f> image_points_contour; // the 2D landmark points
+        std::vector<int> vertex_indices_contour; // their corresponding 3D vertex indices
+
+        // For each 2D contour landmark, get the corresponding 3D vertex point and vertex id:
+        std::tie(image_points_contour, std::ignore, vertex_indices_contour) =
+                eos::fitting::get_contour_correspondences(landmarks, landmarks_contour, model_contour,
+                                                          static_cast<float>(
+                                                                  glm::degrees(camera.get_euler_rotation()[1])),
+                                                          morphable_model->get_mean(),
+                                                          camera.calculate_translation_matrix() *
+                                                                  camera.calculate_rotation_matrix(),
+                                                          camera.calculate_projection_matrix(),
+                                                          camera.get_viewport());
+
+        auto contour_landmarks = core::IndexedLandmarkCollection<LandmarkType>();
+        for (int i = 0; i < image_points_contour.size(); ++i) {
+            core::IndexedLandmark<LandmarkType> landmark;
+            landmark.coordinates = image_points_contour[i];
+            landmark.model_index = vertex_indices_contour[i];
+
+            contour_landmarks.emplace_back(std::move(landmark));
+        }
+
+        return contour_landmarks;
+    }
+
+    /**
+     * Apply estimated shapes and blendshapes to morhable model and returns points.
+     */
+    Eigen::VectorXf calculate_estimated_points_positions() const {
+        auto blendshape_coefficients_float = std::vector<float>(std::begin(blendshape_coefficients),
+                                                                std::end(blendshape_coefficients));
+        return morphable_model->get_shape_model().draw_sample(shape_coefficients) +
+               to_matrix(*blendshapes) * Eigen::Map<const Eigen::VectorXf>(blendshape_coefficients_float.data(),
+                                                                           blendshape_coefficients_float.size());
+    }
+
+    /**
+     * Add residual block with camera cost function to the overall problem
+     *
+     * @param[in] camera camera to fit
+     * @param[in] landmarks all landmarks with indices corresponding to model
+    */
+    template<typename LandmarkType, bool use_perspective>
+    void add_camera_cost_function(CameraParameters<use_perspective>& camera,
+                                  const core::IndexedLandmarkCollection<LandmarkType>& landmarks) {
+        auto& camera_rotation = camera.rotation_quaternion;
+        auto& camera_translation_and_intrinsics = camera.translation_and_intrinsics;
+        for (const auto& landmark : landmarks)
+        {
+            /* Templates: CostFunctor, num residuals, camera rotation (quaternion),
+                          camera translation & fov/frustum_scale, shape-coeffs, bs-coeffs */
+            auto* cost_function = new ceres::AutoDiffCostFunction<fitting::LandmarkCost, 2, 4,
+                    get_num_cam_params(use_perspective),
+                    shapes_num, blendshapes_num>(
+                    new LandmarkCost(morphable_model->get_shape_model(),
+                                     *blendshapes, landmark.coordinates, landmark.model_index,
+                                     camera.image_cols, camera.image_rows, use_perspective));
+
+            problem->AddResidualBlock(cost_function, nullptr, &camera_rotation[0],
+                                     &camera_translation_and_intrinsics[0], &shape_coefficients[0],
+                                     &blendshape_coefficients[0]);
+        }
+        if (use_perspective)
+        {
+            problem->SetParameterUpperBound(
+                    &camera_translation_and_intrinsics[0], 2,
+                    -std::numeric_limits<float>::epsilon()); // t_z has to be negative
+            problem->SetParameterLowerBound(
+                    &camera_translation_and_intrinsics[0], 3,
+                    std::numeric_limits<float>::epsilon()); // fov in radians, must be > 0
+        } else
+        {
+            problem->SetParameterLowerBound(&camera_translation_and_intrinsics[0], 2,
+                                           1.0); // frustum_scale must be > 0
+        }
+        problem->SetParameterization(&camera_rotation[0], new ceres::QuaternionParameterization);
+    }
+
+
+    /**
+     * Add residual block with shape prior cost function to the overall problem
+     *
+     * @param[in] weight constant to multiply all shapes
+     * @param[in, out] upper and lower bound of each shape_coefficient
+     */
+    void add_shape_prior_cost_function(double weigth = 35.0, double shape_coeff_limit = 3.0) {
+        /* Templates: CostFunctor, num residuals, shape-coeffs */
+        auto* shape_prior_cost = new ceres::AutoDiffCostFunction<fitting::PriorCost, shapes_num, shapes_num>(
+                new fitting::PriorCost(shapes_num, weigth));
+        problem->AddResidualBlock(shape_prior_cost, nullptr, &shape_coefficients[0]);
+        for (int i = 0; i < shapes_num; ++i)
+        {
+            problem->SetParameterLowerBound(&shape_coefficients[0], i, -shape_coeff_limit);
+            problem->SetParameterUpperBound(&shape_coefficients[0], i, shape_coeff_limit);
+        }
+    }
+
+
+    /**
+     * Add residual block with shape prior cost function to the passed problem
+     *
+     * @param[in] weight constant to multiply all blendshapes
+     */
+    void add_blendshape_prior_cost_function(double weigth = 10.0) {
+        /* Templates: CostFunctor, num residuals, blendshape-coeffs */
+        auto* blendshapes_prior_cost =
+                new ceres::AutoDiffCostFunction<fitting::PriorCost,blendshapes_num, blendshapes_num>(
+                        new fitting::PriorCost(blendshapes_num, weigth));
+        problem->AddResidualBlock(blendshapes_prior_cost, nullptr, &blendshape_coefficients[0]);
+
+        for (int i = 0; i < blendshapes_num; ++i) {
+            problem->SetParameterLowerBound(&blendshape_coefficients[0], i, 0.0);
+        }
+    }
+
+
+    #if EOS_CERES_USE_OPENCV == true
+    /**
+     * Add residual block with image cost function to the passed problem
+     *
+     * @param[in, out] camera camera to fit
+     * @param[in] image image to fit
+     */
+    template<bool use_perspective>
+    void add_image_cost_function(CameraParameters<use_perspective>& camera, const cv::Mat& image) {
+        // Add a residual for each vertex:
+        for (int i = 0; i < morphable_model->get_shape_model().get_data_dimension() / 3; ++i) {
+            // Templates: CostFunctor, Residuals: [R, G, B], camera rotation (quaternion),
+            //            camera translation & focal length, shape-coeffs, bs-coeffs, colour coeffs
+
+            auto* cost_function = new ceres::AutoDiffCostFunction<fitting::ImageCost, 3, 4,
+                    get_num_cam_params(use_perspective),
+                    shapes_num, blendshapes_num, color_coeffs_num>(
+                    new fitting::ImageCost(*morphable_model, *blendshapes, image, i, use_perspective));
+
+            problem->AddResidualBlock(cost_function, nullptr, &camera.rotation_quaternion[0],
+                                     &camera.translation_and_intrinsics[0], &shape_coefficients[0],
+                                     &blendshape_coefficients[0], &colour_coefficients[0]);
+        }
+    }
+
+    /**
+     * Add residual block with shape prior cost function to the overall problem
+     *
+     * @param[in] weight constant to multiply all colours
+     * @param[in, out] upper and lower bound of each colour_coefficient
+     */
+    void add_image_prior_cost_function(double weigth = 35.0,
+                                       double color_coeff_limit = 3.0) {
+        // Templates: CostFunctor, num residuals, colour-coeffs
+        auto* colour_prior_cost =
+                new ceres::AutoDiffCostFunction<fitting::PriorCost, color_coeffs_num, color_coeffs_num>(
+                        new fitting::PriorCost(color_coeffs_num, weigth));
+
+        problem->AddResidualBlock(colour_prior_cost, nullptr, &colour_coefficients[0]);
+        for (int i = 0; i < color_coeffs_num; ++i) {
+            problem->SetParameterLowerBound(&colour_coefficients[0], i, -color_coeff_limit);
+            problem->SetParameterUpperBound(&colour_coefficients[0], i, color_coeff_limit);
+        }
+    }
+    #endif
+
+    /**
+     * Block shapes fitting
+     */
+    void block_shapes_fitting() {
+        problem->SetParameterBlockConstant(&shape_coefficients[0]);
+    }
+
+    /**
+     * Block blendshapes fitting
+     */
+    void block_blendshapes_fitting() {
+        problem->SetParameterBlockConstant(&blendshape_coefficients[0]);
+    }
+
+    /**
+     * Block fov fitting
+     *
+     * Note: it is only for perspective projection. It have no sense in case of ortogonal projection.
+     *
+     * @param[in,out] camera perspective camera to fit
+     * @param[in] fov_in_grad field of view to fix
+     */
+    void block_fov_fitting(PerspectiveCameraParameters& camera, double fov_in_grad) {
+        auto& camera_translation_and_intrinsics = camera.translation_and_intrinsics;
+        camera_translation_and_intrinsics[3] = glm::radians(fov_in_grad);
+
+        std::vector<int> vec_constant_extrinsic = {3};
+        auto subset_parameterization =
+                new ceres::SubsetParameterization(static_cast<int>(get_num_cam_params(true)),
+                                                  vec_constant_extrinsic);
+        problem->SetParameterization(&camera_translation_and_intrinsics[0], subset_parameterization);
+    }
+
+    darray<shapes_num> shape_coefficients;
+    darray<blendshapes_num> blendshape_coefficients;
+#if EOS_CERES_USE_OPENCV == true
+    darray<color_coeffs_num> colour_coefficients;
+#endif
+
+    std::unique_ptr<ceres::Problem> problem;
+private:
+    /*
+     * Check if blendshapes is not nullptr or try to find them in morphable_model.
+     *
+     * * @return std::array with 3 or 4 (for perspective projection) parameters.
+     */
+    auto find_blendshapes(const morphablemodel::Blendshapes* const blendshapes = nullptr) const {
+        if (blendshapes == nullptr) {
+            const auto& blendshapes_optional = morphable_model->get_expression_model();
+
+            if (blendshapes_optional.has_value())
+            {
+                return &cpp17::get<morphablemodel::Blendshapes>(*blendshapes_optional);
+            }
+            else
+            {
+                throw std::runtime_error("Blendshapes was not passed and morphable model does not contain them too."
+                                         "Try to pass blendshapes explicitly.");
+            }
+        } else {
+            return blendshapes;
+        }
+    }
+
+    const morphablemodel::MorphableModel* const morphable_model;
+    const morphablemodel::Blendshapes* const blendshapes;
+};
+
 } /* namespace fitting */
 } /* namespace eos */
-
-#endif /* CERESNONLINEAR_HPP_ */

--- a/include/eos/fitting/contour_correspondence.hpp
+++ b/include/eos/fitting/contour_correspondence.hpp
@@ -78,7 +78,7 @@ struct ModelContour
 
     // We store r/l separately because we currently only fit to the contour facing the camera.
     // Also if we were to fit to the whole contour: Be careful not to just fit to the closest. The
-    // "invisible" ones behind might be closer on an e.g 90° angle. Store CNT for left/right side separately?
+    // "invisible" ones behind might be closer on an e.g 90Â° angle. Store CNT for left/right side separately?
 
     /**
      * Helper method to load a ModelContour from
@@ -146,6 +146,10 @@ struct ContourLandmarks
     std::vector<std::string> left_contour;
 
     // Note: We store r/l separately because we currently only fit to the contour facing the camera.
+
+    bool empty() const {
+        return right_contour.empty() && left_contour.empty();
+    }
 
     /**
      * Helper method to load contour landmarks from a text file with landmark
@@ -261,7 +265,7 @@ get_contour_correspondences(const core::LandmarkCollection<Eigen::Vector2f>& lan
  * have different size. 
  * Correspondence can be established using get_nearest_contour_correspondences().
  *
- * If the yaw angle is between +-7.5°, both contours will be selected.
+ * If the yaw angle is between +-7.5Â°, both contours will be selected.
  *
  * @param[in] yaw_angle Yaw angle in degrees.
  * @param[in] contour_landmarks 2D image contour ids of left or right side (for example for ibug landmarks).
@@ -294,7 +298,7 @@ select_contour(float yaw_angle, const ContourLandmarks& contour_landmarks, const
                                             begin(contour_landmarks.left_contour),
                                             end(contour_landmarks.left_contour));
     }
-    // Note there's an overlap between the angles - if a subject is between +- 7.5°, both contours get added.
+    // Note there's an overlap between the angles - if a subject is between +- 7.5Â°, both contours get added.
     return std::make_pair(contour_landmark_identifiers, model_contour_indices);
 };
 

--- a/include/eos/morphablemodel/MorphableModel.hpp
+++ b/include/eos/morphablemodel/MorphableModel.hpp
@@ -177,8 +177,9 @@ public:
         core::Mesh mesh;
         if (has_texture_coordinates())
         {
-            mesh = sample_to_mesh(shape, color, shape_model.get_triangle_list(),
-                                  color_model.get_triangle_list(), texture_coordinates);
+            mesh =
+                sample_to_mesh(shape, color, shape_model.get_triangle_list(), color_model.get_triangle_list(),
+                               texture_coordinates, texture_triangle_indices);
         } else
         {
             mesh = sample_to_mesh(shape, color, shape_model.get_triangle_list(),
@@ -214,7 +215,8 @@ public:
         if (has_texture_coordinates())
         {
             mesh = sample_to_mesh(shape_sample, color_sample, shape_model.get_triangle_list(),
-                                  color_model.get_triangle_list(), texture_coordinates);
+                                  color_model.get_triangle_list(), texture_coordinates,
+                                  texture_triangle_indices);
         } else
         {
             mesh = sample_to_mesh(shape_sample, color_sample, shape_model.get_triangle_list(),
@@ -265,7 +267,8 @@ public:
         if (has_texture_coordinates())
         {
             mesh = sample_to_mesh(shape_sample, color_sample, shape_model.get_triangle_list(),
-                                  color_model.get_triangle_list(), texture_coordinates);
+                                  color_model.get_triangle_list(), texture_coordinates,
+                                  texture_triangle_indices);
         } else
         {
             mesh = sample_to_mesh(shape_sample, color_sample, shape_model.get_triangle_list(),
@@ -353,7 +356,8 @@ public:
         if (has_texture_coordinates())
         {
             mesh = sample_to_mesh(shape_sample, color_sample, shape_model.get_triangle_list(),
-                                  color_model.get_triangle_list(), texture_coordinates);
+                                  color_model.get_triangle_list(), texture_coordinates,
+                                  texture_triangle_indices);
         } else
         {
             mesh = sample_to_mesh(shape_sample, color_sample, shape_model.get_triangle_list(),

--- a/include/eos/morphablemodel/PcaModel.hpp
+++ b/include/eos/morphablemodel/PcaModel.hpp
@@ -193,6 +193,14 @@ public:
         return draw_sample(coeffs_float);
     };
 
+    template<std::size_t N>
+    Eigen::VectorXf draw_sample(std::array<double, N> coefficients) const
+    {
+        // We have to convert the vector of doubles to float:
+        const std::vector<float> coeffs_float(std::begin(coefficients), std::end(coefficients));
+        return draw_sample(coeffs_float);
+    };
+
     /**
      * Returns the PCA basis matrix, i.e. the eigenvectors.
      * Each column of the matrix is an eigenvector.


### PR DESCRIPTION
Add `ModelFitter` class that encapsulates ceres fitting logic. Using it the user can build needed cost function. Also, it supports a few cameras fitting. Pull request changes ceres example too.