### PR TITLE
make v2 version of the texture extraction inline

### DIFF
--- a/include/eos/render/texture_extraction.hpp
+++ b/include/eos/render/texture_extraction.hpp
@@ -544,7 +544,7 @@ namespace v2 {
  * @param[in] isomap_resolution The resolution of the generated isomap. Defaults to 512x512.
  * @return The extracted texture as isomap (texture map).
  */
-eos::core::Image4u extract_texture(const core::Mesh& mesh, glm::mat4x4 view_model_matrix, glm::mat4x4 projection_matrix,
+inline eos::core::Image4u extract_texture(const core::Mesh& mesh, glm::mat4x4 view_model_matrix, glm::mat4x4 projection_matrix,
                         glm::vec4 /*viewport, not needed at the moment */, const eos::core::Image4u& image,
                         bool /* compute_view_angle, unused atm */, int isomap_resolution = 512)
 {

--- a/include/eos/render/texture_extraction.hpp
+++ b/include/eos/render/texture_extraction.hpp
@@ -544,9 +544,10 @@ namespace v2 {
  * @param[in] isomap_resolution The resolution of the generated isomap. Defaults to 512x512.
  * @return The extracted texture as isomap (texture map).
  */
-inline eos::core::Image4u extract_texture(const core::Mesh& mesh, glm::mat4x4 view_model_matrix, glm::mat4x4 projection_matrix,
-                        glm::vec4 /*viewport, not needed at the moment */, const eos::core::Image4u& image,
-                        bool /* compute_view_angle, unused atm */, int isomap_resolution = 512)
+inline eos::core::Image4u
+extract_texture(const core::Mesh& mesh, glm::mat4x4 view_model_matrix, glm::mat4x4 projection_matrix,
+                glm::vec4 /*viewport, not needed at the moment */, const eos::core::Image4u& image,
+                bool /* compute_view_angle, unused atm */, int isomap_resolution = 512)
 {
     using detail::divide_by_w;
     using glm::vec2;


### PR DESCRIPTION
I've encountered a linker error after including the texture extraction header in multiple places. The problem seems to be that the v2 version of the `extract_texture` function is not `inline`. If this is intentional for some reason please correct me since I am quite new to C++.