### PR TITLE
Adding more fitting python bindings

### DIFF
--- a/include/eos/fitting/fitting.hpp
+++ b/include/eos/fitting/fitting.hpp
@@ -849,40 +849,7 @@ inline std::pair<core::Mesh, fitting::RenderingParameters> fit_shape_and_pose(
     using Eigen::VectorXf;
     using std::vector;
 
-    if (!num_shape_coefficients_to_fit)
-    {
-        num_shape_coefficients_to_fit = morphable_model.get_shape_model().get_num_principal_components();
-    }
-
-    if (pca_shape_coefficients.empty())
-    {
-        pca_shape_coefficients.resize(num_shape_coefficients_to_fit.value());
-    }
-    // Todo: This leaves the following case open: num_coeffs given is empty or defined, but the
-    // pca_shape_coefficients given is != num_coeffs or the model's max-coeffs. What to do then? Handle & document!
-
-    /*if (expression_coefficients.empty())
-    {
-        expression_coefficients.resize(blendshapes.size());
-    }*/
-
-    // Current mesh - either from the given coefficients, or the mean:
-    VectorXf current_pca_shape = morphable_model.get_shape_model().draw_sample(pca_shape_coefficients);
-    assert(morphable_model.has_separate_expression_model()); // Note: We could also just skip the expression fitting in this case.
-    // Note we don't check whether the shape and expression model dimensions match.
-    // Note: We're calling this in a loop, and morphablemodel::to_matrix(expression_blendshapes) now gets
-    // called again in every fitting iteration.
-    VectorXf current_combined_shape =
-        current_pca_shape +
-        draw_sample(morphable_model.get_expression_model().value(), expression_coefficients);
-    auto current_mesh = morphablemodel::sample_to_mesh(
-        current_combined_shape, morphable_model.get_color_model().get_mean(),
-        morphable_model.get_shape_model().get_triangle_list(),
-        morphable_model.get_color_model().get_triangle_list(), morphable_model.get_texture_coordinates(),
-        morphable_model.get_texture_triangle_indices());
-
     // The 2D and 3D point correspondences used for the fitting:
-    vector<Vector4f> model_points; // the points in the 3D shape model
     vector<int> vertex_indices; // their vertex indices
     vector<Vector2f> image_points; // the corresponding 2D landmark points
 
@@ -916,78 +883,15 @@ inline std::pair<core::Mesh, fitting::RenderingParameters> fit_shape_and_pose(
         {
             vertex_idx = std::stoi(converted_name.value());
         }
-        model_points.emplace_back(current_mesh.vertices[vertex_idx].homogeneous());
+        // model_points.emplace_back(current_mesh.vertices[vertex_idx].homogeneous());
         vertex_indices.emplace_back(vertex_idx);
         image_points.emplace_back(landmarks[i].coordinates);
     }
 
-    // Need to do an initial pose fit to do the contour fitting inside the loop.
-    // We'll do an expression fit too, since face shapes vary quite a lot, depending on expressions.
-    fitting::ScaledOrthoProjectionParameters current_pose =
-        fitting::estimate_orthographic_projection_linear(image_points, model_points, true, image_height);
-    fitting::RenderingParameters rendering_params(current_pose, image_width, image_height);
-
-    const Eigen::Matrix<float, 3, 4> affine_from_ortho =
-        fitting::get_3x4_affine_camera_matrix(rendering_params, image_width, image_height);
-    expression_coefficients =
-        fit_expressions(morphable_model.get_expression_model().value(), current_pca_shape, affine_from_ortho,
-                        image_points, vertex_indices, lambda_expressions, num_expression_coefficients_to_fit);
-
-    // Mesh with same PCA coeffs as before, but new expression fit (this is relevant if no initial blendshape coeffs have been given):
-    current_combined_shape = current_pca_shape + draw_sample(morphable_model.get_expression_model().value(),
-                                                             expression_coefficients);
-    current_mesh = morphablemodel::sample_to_mesh(
-        current_combined_shape, morphable_model.get_color_model().get_mean(),
-        morphable_model.get_shape_model().get_triangle_list(),
-        morphable_model.get_color_model().get_triangle_list(), morphable_model.get_texture_coordinates(),
-        morphable_model.get_texture_triangle_indices());
-
-    for (int i = 0; i < num_iterations; ++i)
-    {
-        // Get the model points of the current mesh, for all correspondences that we've got:
-        model_points.clear();
-        for (auto v : vertex_indices)
-        {
-            model_points.push_back({current_mesh.vertices[v][0], current_mesh.vertices[v][1],
-                                    current_mesh.vertices[v][2], 1.0f});
-        }
-
-        // Re-estimate the pose, using all correspondences:
-        current_pose =
-            fitting::estimate_orthographic_projection_linear(image_points, model_points, true, image_height);
-        rendering_params = fitting::RenderingParameters(current_pose, image_width, image_height);
-
-        const Eigen::Matrix<float, 3, 4> affine_from_ortho =
-            fitting::get_3x4_affine_camera_matrix(rendering_params, image_width, image_height);
-
-        // Estimate the PCA shape coefficients with the current blendshape coefficients:
-        const VectorXf mean_plus_expressions =
-            morphable_model.get_shape_model().get_mean() +
-            draw_sample(morphable_model.get_expression_model().value(), expression_coefficients);
-        pca_shape_coefficients = fitting::fit_shape_to_landmarks_linear(
-            morphable_model.get_shape_model(), affine_from_ortho, image_points, vertex_indices,
-            mean_plus_expressions, lambda_identity, num_shape_coefficients_to_fit);
-
-        // Estimate the blendshape coefficients with the current PCA model estimate:
-        current_pca_shape = morphable_model.get_shape_model().draw_sample(pca_shape_coefficients);
-        expression_coefficients = fit_expressions(
-            morphable_model.get_expression_model().value(), current_pca_shape, affine_from_ortho,
-            image_points, vertex_indices, lambda_expressions, num_expression_coefficients_to_fit);
-
-        current_combined_shape =
-            current_pca_shape +
-            draw_sample(morphable_model.get_expression_model().value(), expression_coefficients);
-        current_mesh = morphablemodel::sample_to_mesh(
-            current_combined_shape, morphable_model.get_color_model().get_mean(),
-            morphable_model.get_shape_model().get_triangle_list(),
-            morphable_model.get_color_model().get_triangle_list(), morphable_model.get_texture_coordinates(),
-            morphable_model.get_texture_triangle_indices());
-    }
-
-    fitted_image_points = image_points;
-    return {current_mesh, rendering_params}; // I think we could also work with a VectorXf face_instance in
-                                             // this function instead of a Mesh, but it would convolute the
-                                             // code more (i.e. more complicated to access vertices).
+    return fit_shape_and_pose(morphable_model, image_points, vertex_indices, image_width, image_height,
+                              num_iterations, num_shape_coefficients_to_fit, lambda_identity,
+                              num_expression_coefficients_to_fit, lambda_expressions, pca_shape_coefficients,
+                              expression_coefficients, fitted_image_points);
 };
 
 /**

--- a/include/eos/morphablemodel/MorphableModel.hpp
+++ b/include/eos/morphablemodel/MorphableModel.hpp
@@ -412,9 +412,9 @@ public:
      * The landmark definitions define mappings from a set of global landmark identifiers, like for
      * example "eye.right.outer_corner", to the model's respective vertex indices.
      */
-    void set_landmark_definitions(std::unordered_map<std::string, int> landmark_definitions)
+    void set_landmark_definitions(cpp17::optional<std::unordered_map<std::string, int>> landmark_definitions)
     {
-        landmark_definitions = landmark_definitions;
+        this->landmark_definitions = landmark_definitions;
     };
 
     /**

--- a/include/eos/morphablemodel/MorphableModel.hpp
+++ b/include/eos/morphablemodel/MorphableModel.hpp
@@ -63,11 +63,12 @@ core::Mesh sample_to_mesh(
     const std::vector<std::array<int, 3>>& texture_triangle_indices = std::vector<std::array<int, 3>>());
 
 /**
- * @brief A class representing a 3D Morphable Model, consisting
- * of a shape- and colour (albedo) PCA model.
+ * @brief A class representing a 3D Morphable Model, consisting of a shape- and colour (albedo) PCA model. It
+ * can additionally contain an optional expression model, which can be a PCA model or consist of linear
+ * expression blendshapes.
  *
- * For the general idea of 3DMMs see T. Vetter, V. Blanz,
- * 'A Morphable Model for the Synthesis of 3D Faces', SIGGRAPH 1999.
+ * For the general idea of 3DMMs see T. Vetter, V. Blanz, 'A Morphable Model for the Synthesis of 3D Faces',
+ * SIGGRAPH 1999.
  */
 class MorphableModel
 {

--- a/include/eos/morphablemodel/MorphableModel.hpp
+++ b/include/eos/morphablemodel/MorphableModel.hpp
@@ -394,7 +394,7 @@ public:
      * Returns the landmark definitions for this Morphable Model, which might be an empty optional, if the
      * model doesn't contain any.
      *
-     * The landmark definitions are define mappings from a set of global landmark identifiers, like for
+     * The landmark definitions define mappings from a set of global landmark identifiers, like for
      * example "eye.right.outer_corner", to the model's respective vertex indices.
      * A MorphableModel may or may not contain these landmark definitions, depending on how it was created.
      *
@@ -408,13 +408,12 @@ public:
     /**
      * Sets the landmark definitions for this Morphable Model.
      *
-     * The landmark definitions are define mappings from a set of global landmark identifiers, like for
+     * The landmark definitions define mappings from a set of global landmark identifiers, like for
      * example "eye.right.outer_corner", to the model's respective vertex indices.
-     *
      */
-    const void set_landmark_definitions(cpp17::optional<std::unordered_map<std::string, int>> updated_landmark_definitions)
+    void set_landmark_definitions(std::unordered_map<std::string, int> landmark_definitions)
     {
-        landmark_definitions = updated_landmark_definitions;
+        landmark_definitions = landmark_definitions;
     };
 
     /**

--- a/include/eos/morphablemodel/MorphableModel.hpp
+++ b/include/eos/morphablemodel/MorphableModel.hpp
@@ -406,6 +406,18 @@ public:
     };
 
     /**
+     * Sets the landmark definitions for this Morphable Model.
+     *
+     * The landmark definitions are define mappings from a set of global landmark identifiers, like for
+     * example "eye.right.outer_corner", to the model's respective vertex indices.
+     *
+     */
+    const void set_landmark_definitions(cpp17::optional<std::unordered_map<std::string, int>> updated_landmark_definitions)
+    {
+        landmark_definitions = updated_landmark_definitions;
+    };
+
+    /**
      * Returns the texture coordinates for all the vertices in the model.
      *
      * @return The texture coordinates for the model vertices.

--- a/python/generate-python-bindings.cpp
+++ b/python/generate-python-bindings.cpp
@@ -208,7 +208,7 @@ PYBIND11_MODULE(eos, eos_module)
         .def("has_color_model", &morphablemodel::MorphableModel::has_color_model, "Returns true if this Morphable Model contains a colour model, and false if it is a shape-only model.")
         .def("has_separate_expression_model", &morphablemodel::MorphableModel::has_separate_expression_model, "Returns true if this Morphable Model contains a separate PCA or Blendshapes expression model.")
         .def("get_landmark_definitions", &morphablemodel::MorphableModel::get_landmark_definitions, "Returns the landmark definitions for this Morphable Model, which might be an empty optional, if the model doesn't contain any.")
-        .def("set_landmark_definitions", &morphablemodel::MorphableModel::set_landmark_definitions, "Sets the landmark definitions for this Morphable Model.", py::arg("updated_landmark_definitions"))
+        .def("set_landmark_definitions", &morphablemodel::MorphableModel::set_landmark_definitions, "Sets the landmark definitions for this Morphable Model.", py::arg("landmark_definitions"))
         .def("get_texture_coordinates", &morphablemodel::MorphableModel::get_texture_coordinates, "Returns the texture coordinates for all the vertices in the model.")
         .def("get_texture_triangle_indices", &morphablemodel::MorphableModel::get_texture_triangle_indices, "Returns the triangulation (the triangles that make up the uv mapping) for the texture coordinates.")
         .def("get_expression_model_type", &morphablemodel::MorphableModel::get_expression_model_type, "Returns the type of the expression model: None, Blendshapes or PcaModel.");

--- a/python/generate-python-bindings.cpp
+++ b/python/generate-python-bindings.cpp
@@ -208,6 +208,7 @@ PYBIND11_MODULE(eos, eos_module)
         .def("has_color_model", &morphablemodel::MorphableModel::has_color_model, "Returns true if this Morphable Model contains a colour model, and false if it is a shape-only model.")
         .def("has_separate_expression_model", &morphablemodel::MorphableModel::has_separate_expression_model, "Returns true if this Morphable Model contains a separate PCA or Blendshapes expression model.")
         .def("get_landmark_definitions", &morphablemodel::MorphableModel::get_landmark_definitions, "Returns the landmark definitions for this Morphable Model, which might be an empty optional, if the model doesn't contain any.")
+        .def("set_landmark_definitions", &morphablemodel::MorphableModel::set_landmark_definitions, "Sets the landmark definitions for this Morphable Model.", py::arg("updated_landmark_definitions"))
         .def("get_texture_coordinates", &morphablemodel::MorphableModel::get_texture_coordinates, "Returns the texture coordinates for all the vertices in the model.")
         .def("get_texture_triangle_indices", &morphablemodel::MorphableModel::get_texture_triangle_indices, "Returns the triangulation (the triangles that make up the uv mapping) for the texture coordinates.")
         .def("get_expression_model_type", &morphablemodel::MorphableModel::get_expression_model_type, "Returns the type of the expression model: None, Blendshapes or PcaModel.");

--- a/python/generate-python-bindings.cpp
+++ b/python/generate-python-bindings.cpp
@@ -338,6 +338,33 @@ PYBIND11_MODULE(eos, eos_module)
         py::arg("num_expression_coefficients_to_fit") = py::none(), py::arg("lambda_expressions") = 30.0f);
 
     fitting_module.def(
+        "fit_shape_and_pose",
+        [](const morphablemodel::MorphableModel& morphable_model,
+           const core::LandmarkCollection<Eigen::Vector2f>& landmarks,
+           const core::LandmarkMapper& landmark_mapper, int image_width, int image_height,
+           int num_iterations, cpp17::optional<int> num_shape_coefficients_to_fit, float lambda_identity,
+           cpp17::optional<int> num_expression_coefficients_to_fit,
+           cpp17::optional<float> lambda_expressions,
+           std::vector<float> pca_coeffs,
+           std::vector<float> blendshape_coeffs,
+           std::vector<Eigen::Vector2f> fitted_image_points) {
+            const auto result = fitting::fit_shape_and_pose(
+                morphable_model, landmarks, landmark_mapper, image_width, image_height,
+                num_iterations, num_shape_coefficients_to_fit,
+                lambda_identity, num_expression_coefficients_to_fit, lambda_expressions, pca_coeffs,
+                blendshape_coeffs, fitted_image_points);
+            return std::make_tuple(result.first, result.second, pca_coeffs, blendshape_coeffs);
+        },
+        "Fit the pose (camera), shape model, and expression blendshapes to landmarks, in an iterative way. "
+        "Returns a tuple (mesh, rendering_parameters, shape_coefficients, blendshape_coefficients).",
+        py::arg("morphable_model"), py::arg("landmarks"), py::arg("landmark_mapper"), py::arg("image_width"),
+        py::arg("image_height"), py::arg("num_iterations") = 5,
+        py::arg("num_shape_coefficients_to_fit") = py::none(), py::arg("lambda_identity") = 30.0f,
+        py::arg("num_expression_coefficients_to_fit") = py::none(), py::arg("lambda_expressions") = 30.0f,
+        py::arg("pca_coeffs") = std::vector<float>(), py::arg("blendshape_coeffs") = std::vector<float>(),
+        py::arg("fitted_image_points") = std::vector<Eigen::Vector2f>());
+
+    fitting_module.def(
         "fit_shape_to_landmarks_linear",
         [](const morphablemodel::PcaModel& shape_model,
            const Eigen::Matrix<float, 3, 4>& affine_camera_matrix,


### PR DESCRIPTION
Added set_landmark_definitions and altered fit_shape_and_pose to allow fitting without contour.

Note: for the modified fit_shape_and_pose, I allowed users to also pass in pca_coeffs and blendshape_coeffs. This makes it easier to control what is being fitted. I can do the same for the other bindings if you're happy with the approach.