### PR TITLE
Modifying the landmark mapper loop to support hybrid mappings

### DIFF
--- a/include/eos/fitting/fitting.hpp
+++ b/include/eos/fitting/fitting.hpp
@@ -366,7 +366,7 @@ inline std::pair<core::Mesh, fitting::RenderingParameters> fit_shape_and_pose(
     // and get the corresponding model points (mean if given no initial coeffs, from the computed shape otherwise):
     for (int i = 0; i < landmarks.size(); ++i)
     {
-        std::optional<int> vertex_idx = get_vertex_index(landmarks[i].name, landmark_mapper, morphable_model.get_landmark_definitions());
+        const cpp17::optional<int> vertex_idx = get_vertex_index(landmarks[i].name, landmark_mapper, morphable_model.get_landmark_definitions());
         if (!vertex_idx) // vertex index not defined for the current landmark
         {
             continue;
@@ -830,7 +830,7 @@ inline std::pair<core::Mesh, fitting::RenderingParameters> fit_shape_and_pose(
     // and get the corresponding model points (mean if given no initial coeffs, from the computed shape otherwise):
     for (int i = 0; i < landmarks.size(); ++i)
     {
-        std::optional<int> vertex_idx = get_vertex_index(landmarks[i].name, landmark_mapper, morphable_model.get_landmark_definitions());
+        const cpp17::optional<int> vertex_idx = get_vertex_index(landmarks[i].name, landmark_mapper, morphable_model.get_landmark_definitions());
         if (!vertex_idx) // vertex index not defined for the current landmark
         {
             continue;

--- a/include/eos/fitting/fitting.hpp
+++ b/include/eos/fitting/fitting.hpp
@@ -865,23 +865,23 @@ inline std::pair<core::Mesh, fitting::RenderingParameters> fit_shape_and_pose(
         // If the MorphableModel does not contain landmark definitions, we expect the user to have given us
         // direct mappings (e.g. directly from ibug identifiers to vertex ids). If the model does contain
         // landmark definitions, we expect the user to use mappings from their landmark identifiers (e.g.
-        // ibug) to the landmark definitions, and not to vertex indices.
+        // ibug) to the landmark definitions. Users may also include direct mappings to create a "hybrid" mapping.
         // Todo: This might be worth mentioning in the function documentation of fit_shape_and_pose.
         int vertex_idx;
-        if (morphable_model.get_landmark_definitions())
-        {
-            const auto found_vertex_idx =
-                morphable_model.get_landmark_definitions().value().find(converted_name.value());
-            if (found_vertex_idx != std::end(morphable_model.get_landmark_definitions().value()))
-            {
-                vertex_idx = found_vertex_idx->second;
-            } else
-            {
-                continue;
-            }
-        } else
+        if (std::all_of(converted_name.value().begin(), converted_name.value().end(), ::isdigit))
         {
             vertex_idx = std::stoi(converted_name.value());
+        } else
+        {
+            if (morphable_model.get_landmark_definitions())
+            {
+                const auto found_vertex_idx =
+                    morphable_model.get_landmark_definitions().value().find(converted_name.value());
+                if (found_vertex_idx != std::end(morphable_model.get_landmark_definitions().value()))
+                {
+                    vertex_idx = found_vertex_idx->second;
+                }
+            }
         }
         // model_points.emplace_back(current_mesh.vertices[vertex_idx].homogeneous());
         vertex_indices.emplace_back(vertex_idx);

--- a/include/eos/fitting/fitting.hpp
+++ b/include/eos/fitting/fitting.hpp
@@ -159,8 +159,8 @@ inline Eigen::VectorXf fit_shape(Eigen::Matrix<float, 3, 4> affine_camera_matrix
  * @param[in] landmark_definitions A set of landmark definitions for the model, mapping from identifiers to vertex indices.
  * @return An optional int with the vertex index.
  */
-inline std::optional<int> get_vertex_index(const std::string landmark_name, const core::LandmarkMapper& landmark_mapper, 
-                            cpp17::optional<std::unordered_map<std::string, int>> landmark_definitions)
+inline cpp17::optional<int> get_vertex_index(const std::string landmark_name, const core::LandmarkMapper& landmark_mapper, 
+                            const cpp17::optional<std::unordered_map<std::string, int>>& landmark_definitions)
 {
     const auto converted_name = landmark_mapper.convert(landmark_name);
     if (!converted_name)
@@ -186,11 +186,11 @@ inline std::optional<int> get_vertex_index(const std::string landmark_name, cons
                 vertex_idx = found_vertex_idx->second;
             } else
             {
-                return std::nullopt;
+                return cpp17::nullopt;
             }
         } else
         {
-            return std::nullopt;
+            return cpp17::nullopt;
         }
     }
     return vertex_idx;


### PR DESCRIPTION
@patrikhuber I've modified one of the fitting loops to allow for "hybrid" mappers where some points are mapped from landmark identifier to landmark definitions and others are mapped directly. If you're happy with the change below, I will apply  those changes to the other fitting functions. I was actually thinking of modifying the function `get_corresponding_pointset` which seems to contain a simple landmark conversion loop and is currently not being used. What do you think?