### PR TITLE
Adding cibuildwheel workflow to build and publish wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -78,3 +78,5 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -62,7 +62,7 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {package}/tests
-          CIBW_TEST_SKIP: *-macosx_arm64
+          CIBW_TEST_SKIP: "*-macosx_arm64"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -62,6 +62,7 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_SKIP: *-macosx_arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -23,6 +23,9 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v3
 
+      - name: actions-setup-cmake
+        uses: jwlawson/actions-setup-cmake@v1.14.1
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -61,7 +61,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_TEST_REQUIRES: pytest
-          CIBW_BEFORE_BUILD: pip install numpy -C-Dallow-noblas=true
+          CIBW_BEFORE_BUILD: pip install numpy --config-settings=setup-args="-Dallow-noblas=true" 
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -7,6 +7,29 @@ on:
       - cibuildwheel
 
 jobs:
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+
+    - name: Build sdist
+      run: |
+        python setup.py sdist
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: Source distribution (sdist)
+        path: dist/*.*
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -40,3 +63,18 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_SKIP: pp*
+          CIBW_SKIP: pp* *i686
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -26,10 +26,6 @@ jobs:
       - name: Use cmake
         run: cmake --version
 
-      - name: Use cmake
-        if: matrix.cibw_archs == 'win32'
-        run: cmake -A Win32
-
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
 
@@ -39,6 +35,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_BEFORE_BUILD: [[ "$(python3 -c "import sys; print(sys.maxsize < 2**32)")" = "True" ]] && echo cmake -A Win32 
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - cibuildwheel
+      - master
   release:
     types:
       - published
@@ -83,5 +83,3 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - cibuildwheel
+  # release:
+  #   types:
+  #     - published
 
 jobs:
   make_sdist:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -60,7 +60,6 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: Source distribution (sdist)
         path: dist/*.*
 
   build_wheels:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_BEFORE_BUILD: [[ "$(python3 -c "import sys; print(sys.maxsize < 2**32)")" = "True" ]] && echo cmake -A Win32 
+          CIBW_BEFORE_BUILD: "[[ "$(python3 -c "import sys; print(sys.maxsize < 2**32)")" = "True" ]] && echo cmake -A Win32"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -36,7 +36,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_BEFORE_BUILD: |
-            if [ "$(python -c 'import sys; print(sys.maxsize < 2**32)')" = "True" ]; then
+            if python -c "import sys; exit(0 if sys.maxsize < 2**32 else 1)"; then
               echo "cmake -A Win32"
             fi
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {package}/tests
 
       - uses: actions/upload-artifact@v3
@@ -69,7 +69,7 @@ jobs:
 
   upload_all:
     needs: [build_wheels, make_sdist]
-    environment: pypi numpy
+    environment: pypi
     permissions:
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,7 +35,10 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_BEFORE_BUILD: "[[ "$(python3 -c "import sys; print(sys.maxsize < 2**32)")" = "True" ]] && echo cmake -A Win32"
+          CIBW_BEFORE_BUILD: |
+            if [ "$(python3 -c 'import sys; print(sys.maxsize < 2**32)')" = "True" ]; then
+              echo "cmake -A Win32"
+            fi
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -60,9 +60,10 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_TEST_REQUIRES: pytest numpy
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_BEFORE_BUILD: pip install numpy -C-Dallow-noblas=true
           CIBW_TEST_COMMAND: pytest {package}/tests
-          CIBW_TEST_SKIP: "*-macosx_arm64"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Use cmake
         run: cmake --version
 
+      - name: Use cmake
+        if: matrix.cibw_archs == 'win32'
+        run: cmake -A Win32
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
 
@@ -35,7 +39,6 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -36,7 +36,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_BEFORE_BUILD: |
-            if [ "$(python3 -c 'import sys; print(sys.maxsize < 2**32)')" = "True" ]; then
+            if [ "$(python -c 'import sys; print(sys.maxsize < 2**32)')" = "True" ]; then
               echo "cmake -A Win32"
             fi
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -23,11 +23,6 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v3
 
-      - name: actions-setup-cmake
-        uses: jwlawson/actions-setup-cmake@v1.14.1
-        with:
-          cmake-version: latest
-
       - name: Use cmake
         run: cmake --version
 
@@ -40,6 +35,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -30,7 +30,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         # to supply options, put them in 'env', like:
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.14
+          MACOSX_DEPLOYMENT_TARGET: 10.15
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,8 +35,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_BEFORE_BUILD: 'if [ "$(python -c "import sys; exit(0 if sys.maxsize < 2**32 else 1)")" = "0" ]; then echo "cmake -A Win32"; fi'
-
+          CIBW_BEFORE_BUILD: 'python -c "import sys; sys.exit(0 if sys.maxsize < 2**32 else 1)" && echo "cmake -A Win32"'
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,37 @@
+name: cibuildwheel build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - cibuildwheel
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macOS-11]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.14
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -69,7 +69,7 @@ jobs:
 
   upload_all:
     needs: [build_wheels, make_sdist]
-    environment: pypi
+    environment: pypi numpy
     permissions:
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -26,6 +26,9 @@ jobs:
       - name: actions-setup-cmake
         uses: jwlawson/actions-setup-cmake@v1.14.1
 
+      - name: Use cmake
+        run: cmake --version
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -60,8 +60,8 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_SKIP: pp*
           CIBW_TEST_REQUIRES: pytest
-          CIBW_BEFORE_BUILD: pip install numpy --config-settings=setup-args="-Dallow-noblas=true" 
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: actions-setup-cmake
         uses: jwlawson/actions-setup-cmake@v1.14.1
+        with:
+          cmake-version: latest
 
       - name: Use cmake
         run: cmake --version
@@ -38,7 +40,6 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,10 +35,8 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_BEFORE_BUILD: |
-            if python -c "import sys; exit(0 if sys.maxsize < 2**32 else 1)"; then
-              echo "cmake -A Win32"
-            fi
+          CIBW_BEFORE_BUILD: 'if [ "$(python -c "import sys; exit(0 if sys.maxsize < 2**32 else 1)")" = "0" ]; then echo "cmake -A Win32"; fi'
+
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_BEFORE_BUILD: 'python -c "import sys; sys.exit(0 if sys.maxsize < 2**32 else 1)" && echo "cmake -A Win32"'
+          CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,6 +34,7 @@ jobs:
         # to supply options, put them in 'env', like:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
+          CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,6 +34,7 @@ jobs:
         # to supply options, put them in 'env', like:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
+          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_ARCHS_WINDOWS: auto64
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -5,9 +5,9 @@ on:
   push:
     branches:
       - cibuildwheel
-  # release:
-  #   types:
-  #     - published
+  release:
+    types:
+      - published
 
 jobs:
   make_sdist:
@@ -60,6 +60,8 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {package}/tests
 
       - uses: actions/upload-artifact@v3
         with:
@@ -71,7 +73,7 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -61,7 +61,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_SKIP: pp*
-          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ class CMakeBuild(build_ext):
         build_args = ['--config', cfg]
 
         if platform.system() == "Windows":
+            if platform.architecture()[0] == '32bit':
+                cmake_args += ['-A', 'Win32']
+            else:
+                cmake_args += ['-A', 'x64']
             cmake_args += ['-G', 'Visual Studio 17 2022']
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
             build_args += ['--', '/m']

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import subprocess
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-from packaging.version import Version
+from distutils.version import LooseVersion
 
 
 class CMakeExtension(Extension):
@@ -25,7 +25,7 @@ class CMakeBuild(build_ext):
                                ", ".join(e.name for e in self.extensions))
 
         if platform.system() == "Windows":
-            cmake_version = Version(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
             if cmake_version < '3.10.0':
                 raise RuntimeError("CMake >= 3.10.0 is required on Windows")
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='omar-eos-py',
+    name='eos-py',
     version='1.4.1',
     author='Patrik Huber',
     author_email='patrikhuber@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='omar-eos-py',
-    version='1.4.0.post0',
+    version='1.4.1',
     author='Patrik Huber',
     author_email='patrikhuber@gmail.com',
     description='Python bindings for eos - A lightweight 3D Morphable Face Model fitting library in modern C++11/14',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import subprocess
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 class CMakeExtension(Extension):
@@ -25,7 +25,7 @@ class CMakeBuild(build_ext):
                                ", ".join(e.name for e in self.extensions))
 
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            cmake_version = Version(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
             if cmake_version < '3.10.0':
                 raise RuntimeError("CMake >= 3.10.0 is required on Windows")
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='eos-py',
-    version='1.4.1',
+    version='1.4.0.post0',
     author='Patrik Huber',
     author_email='patrikhuber@gmail.com',
     description='Python bindings for eos - A lightweight 3D Morphable Face Model fitting library in modern C++11/14',

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='eos-py',
+    name='omar-eos-py',
     version='1.4.0.post0',
     author='Patrik Huber',
     author_email='patrikhuber@gmail.com',

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -1,0 +1,6 @@
+import pytest
+import eos
+
+def test_load_model():
+    model = eos.morphablemodel.load_model("../share/sfm_shape_3448.bin")
+    assert model is not None

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -1,5 +1,6 @@
 import pytest
 import eos
+import numpy as np
 
 def test_load_model():
     model = eos.morphablemodel.load_model("../share/sfm_shape_3448.bin")

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -1,7 +1,8 @@
 import pytest
 import eos
 import numpy as np
+from pathlib import Path
 
 def test_load_model():
-    model = eos.morphablemodel.load_model("../share/sfm_shape_3448.bin")
+    model = eos.morphablemodel.load_model(str(Path(__file__).resolve().parent.parent / 'share' / 'sfm_shape_3448.bin'))
     assert model is not None


### PR DESCRIPTION
@patrikhuber Here's a complete workflow. It builds wheels for all systems  and supports all python versions. The only exceptions are Pypy and i686 as those are not fully supported by [numpy](https://github.com/numpy/numpy/issues/24703). The following workflow will run a simple python test after building a wheel to confirm that it works as expected. It will also publish wheels to PyPi. As of now it is triggered by pushes to master but let me know if you'd want it to be enabled for all branches.